### PR TITLE
Bump version to 0.1.1

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "porua_server"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
## Summary
- Bump server version from 0.1.0 to 0.1.1 in Cargo.toml

## Purpose
Preparing to tag v0.1.1 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)