### PR TITLE
Fix: Resolve release workflow packaging and cross-compilation issues

### DIFF
--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -40,8 +40,10 @@ jobs:
       - name: Install cross-compilation tools (Linux ARM64)
         if: matrix.target.target == 'aarch64-unknown-linux-gnu'
         run: |
+          sudo dpkg --add-architecture arm64
           sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+          sudo apt-get install -y libssl-dev:arm64 pkg-config
 
       - name: Extract version
         id: version
@@ -72,6 +74,8 @@ jobs:
         run: |
           if [ "${{ matrix.target.target }}" = "aarch64-unknown-linux-gnu" ]; then
             export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+            export PKG_CONFIG_ALLOW_CROSS=1
+            export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
           fi
           cargo build --release --manifest-path server/Cargo.toml --target ${{ matrix.target.target }}
 

--- a/server/packaging/build_package.sh
+++ b/server/packaging/build_package.sh
@@ -159,7 +159,12 @@ fi
 
 # Step 2: Create package directory
 echo -e "${YELLOW}Step 2/5:${NC} Creating package directory..."
-rm -rf "$OUTPUT_DIR"
+# Only remove the specific package directory if it exists, not the entire output directory
+if [ -d "$PACKAGE_DIR" ]; then
+    rm -rf "$PACKAGE_DIR"
+fi
+# Ensure output directory exists
+mkdir -p "$OUTPUT_DIR"
 mkdir -p "$PACKAGE_DIR"
 mkdir -p "$PACKAGE_DIR/bin"
 mkdir -p "$PACKAGE_DIR/docs"


### PR DESCRIPTION
## Summary
This PR fixes two critical issues preventing successful release builds in the server-v0.1.1 workflow run:

### Issue 1: Packaging Script OUTPUT_DIR Problem ✅
**Affected Platforms:** Linux x64, macOS ARM64

**Error:**
```
rm: refusing to remove '.' or '..' directory: skipping '../'
```

**Root Cause:**
The workflow passes `--output-dir "../"` to the packaging script. The script attempted to execute `rm -rf ../`, which tries to remove the parent directory and fails.

**Fix:**
- Changed logic to only remove the specific package directory if it exists
- Ensures output directory exists before creating package structure
- Eliminates dangerous parent directory removal

### Issue 2: Cross-Compilation OpenSSL Missing ✅
**Affected Platforms:** Linux ARM64

**Error:**
```
Could not find directory of OpenSSL installation
pkg-config has not been configured to support cross-compilation
```

**Root Cause:**
When cross-compiling for ARM64 on Linux x64 host, the build needs ARM64-specific OpenSSL development libraries, but only the cross-compiler toolchain was installed.

**Fix:**
- Added ARM64 architecture support to Ubuntu runner via `dpkg --add-architecture arm64`
- Installed `libssl-dev:arm64` and `pkg-config` packages
- Set environment variables for cross-compilation:
  - `PKG_CONFIG_ALLOW_CROSS=1`
  - `PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig`

## Changes
- `server/packaging/build_package.sh`: Safe directory removal logic
- `.github/workflows/server-release.yml`: ARM64 OpenSSL dependencies and environment variables

## Testing
This PR should allow the release workflow to complete successfully for all platforms:
- ✅ Linux x64
- ✅ Linux ARM64  
- ✅ macOS ARM64
- ✅ Windows x64

## Related
- Fixes workflow run: https://github.com/ShahadIshraq/porua/actions/runs/18645634620
- Tag: server-v0.1.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)