### PR TITLE
Fix: Include voice sample files in server release packages

### DIFF
--- a/server/packaging/build_package.sh
+++ b/server/packaging/build_package.sh
@@ -235,6 +235,18 @@ else
     exit 1
 fi
 
+# Copy voice samples (should always be in repository)
+if [ -d "samples" ]; then
+    echo -e "${YELLOW}Copying voice samples...${NC}"
+    cp -r samples "$PACKAGE_DIR/"
+    SAMPLES_SIZE=$(du -sh "$PACKAGE_DIR/samples" | cut -f1)
+    echo -e "${GREEN}✓ Voice samples copied${NC} (${SAMPLES_SIZE})"
+else
+    echo -e "${YELLOW}Warning: samples directory not found${NC}"
+    echo -e "${YELLOW}Voice preview functionality will not be available.${NC}"
+    echo -e "${YELLOW}Run 'cargo run --bin generate_samples' to create samples.${NC}"
+fi
+
 echo -e "${GREEN}✓ Documentation copied${NC}"
 echo ""
 


### PR DESCRIPTION
Problem:
- The server-release workflow was not packaging the samples/ directory
- This directory contains 28 pre-generated WAV files (~73 MB) for voice previews
- The server serves these files at /samples/{voice_id}.wav endpoint
- Without samples, voice preview functionality returns 404 errors

Solution:
- Added code to copy samples/ directory in server/packaging/build_package.sh
- Implemented similar to espeak-ng-data copying (lines 238-248)
- Non-fatal warning if samples missing (with guidance to generate them)
- Package size increases from ~30 MB to ~100 MB (with espeak-ng-data + samples)

Testing:
- Verified packaging script syntax
- Test package successfully includes all 28 sample WAV files
- Package structure validated with tree output

Impact:
- Users can now preview all 28 voices via the /samples endpoint
- /voices API response sample_url fields will work correctly
- Better user experience for voice selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)