### PR TITLE
Fix: Add CORS expose_headers for cross-origin stream endpoint access

### DIFF
--- a/server/src/server.rs
+++ b/server/src/server.rs
@@ -210,10 +210,12 @@ async fn generate_tts_stream(
 /// Create and configure the HTTP server router
 pub fn create_router(state: AppState) -> Router<()> {
     // Configure CORS to allow all origins (adjust as needed for production)
+    // Expose headers needed for streaming responses (multipart/mixed with chunked encoding)
     let cors = CorsLayer::new()
         .allow_origin(Any)
         .allow_methods(Any)
-        .allow_headers(Any);
+        .allow_headers(Any)
+        .expose_headers(Any); // Expose all response headers for streaming compatibility
 
     // Clone api_keys for middleware
     let api_keys_for_middleware = state.api_keys.clone();


### PR DESCRIPTION
The stream fetch API was not working from other devices on the network due to missing CORS configuration. While the server correctly allowed cross-origin requests, it did not expose response headers to clients.

The streaming endpoint uses:
- Content-Type: multipart/mixed (with boundary)
- Transfer-Encoding: chunked

Without exposed headers, browsers cannot read these headers in cross-origin contexts, preventing proper parsing of the multipart streaming response.

**Changes:**
- Added `.expose_headers(Any)` to CORS configuration in server.rs:218
- Allows clients to read all response headers, including Content-Type and Transfer-Encoding needed for streaming responses

**Impact:**
- Fixes stream endpoint access from other network devices
- No firewall changes needed - issue was CORS, not network layer
- Regular /tts endpoint unaffected (already working)

Resolves the issue where /tts/stream fails from remote devices while other endpoints work correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)