### PR TITLE
Fix: Update manifests to reference bundled CSS files

### DIFF
--- a/plugin/manifest.firefox.json
+++ b/plugin/manifest.firefox.json
@@ -21,12 +21,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["dist/content.js"],
-      "css": [
-        "src/styles/variables.css",
-        "src/styles/content/play-button.css",
-        "src/styles/content/player-control.css",
-        "src/styles/content/highlighting.css"
-      ],
+      "css": ["dist/content.css"],
       "run_at": "document_idle"
     }
   ],

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -26,12 +26,7 @@
     {
       "matches": ["<all_urls>"],
       "js": ["dist/content.js"],
-      "css": [
-        "src/styles/variables.css",
-        "src/styles/content/play-button.css",
-        "src/styles/content/player-control.css",
-        "src/styles/content/highlighting.css"
-      ],
+      "css": ["dist/content.css"],
       "run_at": "document_idle"
     }
   ],


### PR DESCRIPTION
## Summary
Fixes manifest files to correctly reference the bundled CSS files in `dist/` directory after CSS minification was added.

## Problem
After adding CSS minification in the previous PR, the extension failed to load with the error:
> Could not load css 'src/styles/variables.css' for script.

This was because the manifest files still referenced the old CSS file paths in `src/styles/`, but those files were no longer being packaged.

## Changes
- Update `manifest.json` to reference `dist/content.css` instead of individual CSS files
- Update `manifest.firefox.json` to reference `dist/content.css` instead of individual CSS files
- CSS files are now bundled and minified via esbuild into a single `dist/content.css` file

## Testing
- ✅ All 1,190 tests passing
- ✅ Extension loads without CSS errors
- ✅ Build and package creation verified
- ✅ Package size: 146 KB (with minified CSS)

## Related
Fixes the issue introduced in PR #38 where manifest files weren't updated to match the new CSS bundling approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)