### PR TITLE
feat: implement screen area capture feature

### DIFF
--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -9,9 +9,36 @@ A lightweight menu bar/system tray application for managing the Porua TTS Server
 ## Features
 
 - **System Tray Control**: Start/Stop the TTS server from your menu bar (macOS) or system tray (Windows)
+- **Screen Capture**: Region-based screen capture with preview and save functionality (Windows only)
 - **Automatic Installation**: First-run installer handles server setup and model downloads
 - **Status Monitoring**: Real-time server status updates
 - **Minimal Footprint**: ~60-70 MB installer, lightweight Tauri-based wrapper
+
+## Screen Capture Feature
+
+### Platform Support
+
+| Feature | Windows | macOS | Linux |
+|---------|---------|-------|-------|
+| Screen Capture | ✅ Full Support | ❌ Not Implemented | ❌ Not Implemented |
+| Selection Overlay | ✅ | Mock only | Mock only |
+| Multi-monitor | ✅ | Mock only | Mock only |
+
+**Windows-Only Implementation**: The screen capture feature uses Windows GDI APIs (`GetDC`, `CreateCompatibleDC`, `BitBlt`, `GetDIBits`) for pixel capture. On non-Windows platforms, a mock backend is used for testing purposes only - actual capture functionality is not available.
+
+### Usage
+
+1. **Trigger capture**: Press `Ctrl+Shift+S` (Windows) or `Cmd+Shift+S` (macOS, mock only) or click "Capture Screen" from tray menu
+2. **Select region**: Click and drag to select the area you want to capture
+3. **Preview**: The captured image opens in a preview window
+4. **Save**: Use the save button to export the image to a location of your choice
+
+### Capture File Management
+
+Captures are saved to a temporary directory and automatically cleaned up after 24 hours. The cleanup runs on app startup.
+
+- **Temp location (Windows)**: `%APPDATA%\Porua\captures\`
+- **Filename format**: `capture_YYYYMMDD_HHMMSS_XXXXXXXX.png`
 
 ## Architecture
 
@@ -59,11 +86,16 @@ npm run build
 
 ```
 wrapper/
-├── src/                    # Frontend (minimal HTML)
-│   └── index.html
+├── src/                    # Frontend (HTML/JS)
+│   ├── index.html          # Installer UI
+│   ├── overlay.html        # Screen capture overlay
+│   ├── overlay.js          # Selection logic
+│   ├── preview.html        # Capture preview window
+│   └── preview.js          # Preview/zoom logic
 ├── src-tauri/              # Rust backend
 │   ├── src/
-│   │   ├── main.rs         # App entry, system tray
+│   │   ├── main.rs         # App entry, system tray, capture commands
+│   │   ├── capture.rs      # Screen capture (Windows-only real impl)
 │   │   ├── server.rs       # Server process management
 │   │   ├── installer.rs    # First-run installation
 │   │   ├── config.rs       # Configuration handling

--- a/wrapper/package.json
+++ b/wrapper/package.json
@@ -5,9 +5,21 @@
   "scripts": {
     "tauri": "tauri",
     "dev": "tauri dev",
-    "build": "tauri build"
+    "build": "tauri build",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "devDependencies": {
-    "@tauri-apps/cli": "^1.5.0"
+    "@tauri-apps/cli": "^1.5.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
+  },
+  "jest": {
+    "testEnvironment": "jsdom",
+    "testMatch": ["**/tests/**/*.test.js"],
+    "moduleFileExtensions": ["js"],
+    "verbose": true,
+    "setupFilesAfterEnv": ["<rootDir>/src/tests/setup.js"]
   }
 }

--- a/wrapper/src-tauri/Cargo.toml
+++ b/wrapper/src-tauri/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 tauri-build = { version = "1.5", features = [] }
 
 [dependencies]
-tauri = { version = "1.5", features = [ "fs-read-dir", "shell-execute", "shell-open", "fs-exists", "fs-create-dir", "http-request", "fs-read-file", "path-all", "notification-all", "fs-copy-file", "fs-write-file", "system-tray", "notification"] }
+tauri = { version = "1.5", features = [ "fs-read-dir", "shell-execute", "shell-open", "fs-exists", "fs-create-dir", "http-request", "fs-read-file", "path-all", "notification-all", "fs-copy-file", "fs-write-file", "system-tray", "notification", "dialog-save", "global-shortcut-all", "window-all", "macos-private-api"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1", features = ["full"] }
@@ -25,6 +25,20 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"
 image = "0.24"
 open = "5.0"
+uuid = { version = "1.0", features = ["v4"] }
+chrono = "0.4"
+
+[target."cfg(windows)".dependencies]
+windows = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
+    "Win32_UI_WindowsAndMessaging",
+    "Win32_UI_HiDpi",
+    "Win32_System_SystemInformation"
+]}
+
+[dev-dependencies]
+tempfile = "3.0"
 
 [features]
 default = ["custom-protocol"]

--- a/wrapper/src-tauri/src/capture.rs
+++ b/wrapper/src-tauri/src/capture.rs
@@ -1,0 +1,778 @@
+//! Screen capture module for Windows platform
+//! Handles monitor detection, DPI scaling, and screen region capture
+
+use anyhow::{anyhow, Result};
+use image::{ImageBuffer, Rgba};
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+use thiserror::Error;
+use tracing::{debug, error, info};
+
+#[cfg(target_os = "windows")]
+use windows::{
+    Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT, TRUE},
+    Win32::Graphics::Gdi::{
+        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
+        GetDC, GetDIBits, ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER,
+        BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC, SRCCOPY,
+    },
+    Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
+    Win32::UI::WindowsAndMessaging::{
+        EnumDisplayMonitors, GetMonitorInfoW, GetSystemMetrics, MONITORINFOEXW,
+        SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+    },
+};
+
+/// Errors that can occur during screen capture operations
+#[derive(Error, Debug)]
+pub enum CaptureError {
+    #[error("Selection too small (minimum 10x10px)")]
+    SelectionTooSmall,
+
+    #[error("Selection outside screen bounds")]
+    OutOfBounds,
+
+    #[error("Failed to capture screen: {0}")]
+    CaptureFailure(String),
+
+    #[error("Failed to save image: {0}")]
+    SaveFailure(String),
+
+    #[error("No monitors detected")]
+    NoMonitors,
+
+    #[error("Permission denied for screen capture")]
+    PermissionDenied,
+
+    #[error("Platform not supported")]
+    PlatformNotSupported,
+}
+
+/// Represents a rectangle with position and dimensions
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+}
+
+impl Rect {
+    pub fn new(x: i32, y: i32, width: u32, height: u32) -> Self {
+        Self { x, y, width, height }
+    }
+
+    /// Create a Rect from two corner points
+    pub fn from_points(x1: i32, y1: i32, x2: i32, y2: i32) -> Self {
+        let x = x1.min(x2);
+        let y = y1.min(y2);
+        let width = (x1 - x2).unsigned_abs();
+        let height = (y1 - y2).unsigned_abs();
+        Self { x, y, width, height }
+    }
+
+    /// Check if the rect has valid minimum dimensions
+    pub fn is_valid_size(&self, min_width: u32, min_height: u32) -> bool {
+        self.width >= min_width && self.height >= min_height
+    }
+}
+
+/// Information about a connected monitor
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MonitorInfo {
+    pub id: u32,
+    pub name: String,
+    pub x: i32,
+    pub y: i32,
+    pub width: u32,
+    pub height: u32,
+    pub dpi_scale: f64,
+    pub is_primary: bool,
+}
+
+/// Result of a screen capture operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CaptureResult {
+    pub file_path: String,
+    pub width: u32,
+    pub height: u32,
+    pub timestamp: String,
+}
+
+/// Main screen capture manager
+pub struct ScreenCapture {
+    temp_dir: PathBuf,
+}
+
+impl ScreenCapture {
+    /// Create a new ScreenCapture instance
+    pub fn new(temp_dir: PathBuf) -> Self {
+        Self { temp_dir }
+    }
+
+    /// Get information about all connected monitors
+    #[cfg(target_os = "windows")]
+    pub fn get_monitors() -> Result<Vec<MonitorInfo>, CaptureError> {
+        let mut monitors: Vec<MonitorInfo> = Vec::new();
+        let monitors_ptr = &mut monitors as *mut Vec<MonitorInfo>;
+
+        unsafe {
+            let result = EnumDisplayMonitors(
+                HDC::default(),
+                None,
+                Some(enum_monitor_callback),
+                LPARAM(monitors_ptr as isize),
+            );
+
+            if !result.as_bool() {
+                return Err(CaptureError::CaptureFailure(
+                    "Failed to enumerate monitors".to_string(),
+                ));
+            }
+        }
+
+        if monitors.is_empty() {
+            return Err(CaptureError::NoMonitors);
+        }
+
+        // Assign IDs
+        for (i, monitor) in monitors.iter_mut().enumerate() {
+            monitor.id = i as u32;
+        }
+
+        debug!("Detected {} monitors", monitors.len());
+        Ok(monitors)
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn get_monitors() -> Result<Vec<MonitorInfo>, CaptureError> {
+        Err(CaptureError::PlatformNotSupported)
+    }
+
+    /// Get the virtual screen bounds (encompasses all monitors)
+    #[cfg(target_os = "windows")]
+    pub fn get_virtual_screen_bounds() -> Rect {
+        unsafe {
+            let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+            let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+            let width = GetSystemMetrics(SM_CXVIRTUALSCREEN) as u32;
+            let height = GetSystemMetrics(SM_CYVIRTUALSCREEN) as u32;
+
+            debug!(
+                "Virtual screen bounds: x={}, y={}, width={}, height={}",
+                x, y, width, height
+            );
+
+            Rect::new(x, y, width, height)
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn get_virtual_screen_bounds() -> Rect {
+        Rect::new(0, 0, 1920, 1080) // Default fallback
+    }
+
+    /// Validate and adjust a selection rectangle
+    pub fn validate_selection(rect: Rect) -> Result<Rect, CaptureError> {
+        // Check minimum size
+        if !rect.is_valid_size(10, 10) {
+            return Err(CaptureError::SelectionTooSmall);
+        }
+
+        // Clamp to screen boundaries
+        let bounds = Self::get_virtual_screen_bounds();
+        let clamped = Self::clamp_rect_to_bounds(rect, bounds);
+
+        Ok(clamped)
+    }
+
+    /// Clamp a rectangle to fit within given bounds
+    pub fn clamp_rect_to_bounds(rect: Rect, bounds: Rect) -> Rect {
+        let x = rect.x.max(bounds.x);
+        let y = rect.y.max(bounds.y);
+
+        let right = (rect.x + rect.width as i32).min(bounds.x + bounds.width as i32);
+        let bottom = (rect.y + rect.height as i32).min(bounds.y + bounds.height as i32);
+
+        let width = (right - x).max(0) as u32;
+        let height = (bottom - y).max(0) as u32;
+
+        Rect::new(x, y, width, height)
+    }
+
+    /// Apply DPI scaling to convert logical coordinates to physical pixels
+    pub fn apply_dpi_scaling(rect: Rect, scale: f64) -> Rect {
+        Rect::new(
+            (rect.x as f64 * scale) as i32,
+            (rect.y as f64 * scale) as i32,
+            (rect.width as f64 * scale) as u32,
+            (rect.height as f64 * scale) as u32,
+        )
+    }
+
+    /// Get DPI scale factor for a specific point on screen
+    #[cfg(target_os = "windows")]
+    pub fn get_dpi_scale_at_point(x: i32, y: i32) -> f64 {
+        use windows::Win32::Graphics::Gdi::MonitorFromPoint;
+        use windows::Win32::Graphics::Gdi::MONITOR_DEFAULTTONEAREST;
+
+        unsafe {
+            let point = POINT { x, y };
+            let monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+
+            let mut dpi_x: u32 = 96;
+            let mut dpi_y: u32 = 96;
+
+            let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+
+            dpi_x as f64 / 96.0
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn get_dpi_scale_at_point(_x: i32, _y: i32) -> f64 {
+        1.0
+    }
+
+    /// Capture a region of the screen and save to file
+    #[cfg(target_os = "windows")]
+    pub fn capture_region(&self, rect: Rect) -> Result<CaptureResult, CaptureError> {
+        info!(
+            "Capturing region: x={}, y={}, width={}, height={}",
+            rect.x, rect.y, rect.width, rect.height
+        );
+
+        // Validate the selection
+        let validated_rect = Self::validate_selection(rect)?;
+
+        // Get DPI scale for the capture area
+        let dpi_scale = Self::get_dpi_scale_at_point(validated_rect.x, validated_rect.y);
+        debug!("DPI scale factor: {}", dpi_scale);
+
+        // Apply DPI scaling to get physical pixel coordinates
+        let physical_rect = Self::apply_dpi_scaling(validated_rect, dpi_scale);
+
+        // Capture the screen region
+        let image_data = self.capture_screen_region_internal(physical_rect)?;
+
+        // Generate unique filename
+        let timestamp = chrono::Local::now();
+        let filename = format!(
+            "capture_{}_{}.png",
+            timestamp.format("%Y%m%d_%H%M%S"),
+            uuid::Uuid::new_v4().to_string().split('-').next().unwrap_or("0000")
+        );
+
+        let file_path = self.temp_dir.join(&filename);
+
+        // Ensure temp directory exists
+        std::fs::create_dir_all(&self.temp_dir).map_err(|e| {
+            CaptureError::SaveFailure(format!("Failed to create temp directory: {}", e))
+        })?;
+
+        // Save the image
+        image_data.save(&file_path).map_err(|e| {
+            CaptureError::SaveFailure(format!("Failed to save image: {}", e))
+        })?;
+
+        info!("Captured image saved to: {:?}", file_path);
+
+        Ok(CaptureResult {
+            file_path: file_path.to_string_lossy().to_string(),
+            width: physical_rect.width,
+            height: physical_rect.height,
+            timestamp: timestamp.format("%Y-%m-%d %H:%M:%S").to_string(),
+        })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn capture_region(&self, _rect: Rect) -> Result<CaptureResult, CaptureError> {
+        Err(CaptureError::PlatformNotSupported)
+    }
+
+    /// Internal function to capture screen pixels using Windows GDI
+    #[cfg(target_os = "windows")]
+    fn capture_screen_region_internal(
+        &self,
+        rect: Rect,
+    ) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
+        unsafe {
+            // Get screen device context
+            let screen_dc = GetDC(HWND::default());
+            if screen_dc.is_invalid() {
+                return Err(CaptureError::CaptureFailure(
+                    "Failed to get screen DC".to_string(),
+                ));
+            }
+
+            // Create compatible DC for the capture
+            let capture_dc = CreateCompatibleDC(screen_dc);
+            if capture_dc.is_invalid() {
+                ReleaseDC(HWND::default(), screen_dc);
+                return Err(CaptureError::CaptureFailure(
+                    "Failed to create compatible DC".to_string(),
+                ));
+            }
+
+            // Create compatible bitmap
+            let bitmap = CreateCompatibleBitmap(screen_dc, rect.width as i32, rect.height as i32);
+            if bitmap.is_invalid() {
+                DeleteDC(capture_dc);
+                ReleaseDC(HWND::default(), screen_dc);
+                return Err(CaptureError::CaptureFailure(
+                    "Failed to create bitmap".to_string(),
+                ));
+            }
+
+            // Select bitmap into DC
+            let old_bitmap = SelectObject(capture_dc, bitmap);
+
+            // Copy screen region to bitmap
+            let result = BitBlt(
+                capture_dc,
+                0,
+                0,
+                rect.width as i32,
+                rect.height as i32,
+                screen_dc,
+                rect.x,
+                rect.y,
+                SRCCOPY,
+            );
+
+            if !result.as_bool() {
+                SelectObject(capture_dc, old_bitmap);
+                DeleteObject(bitmap);
+                DeleteDC(capture_dc);
+                ReleaseDC(HWND::default(), screen_dc);
+                return Err(CaptureError::CaptureFailure(
+                    "BitBlt failed".to_string(),
+                ));
+            }
+
+            // Prepare bitmap info header for extraction
+            let mut bmi = BITMAPINFO {
+                bmiHeader: BITMAPINFOHEADER {
+                    biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                    biWidth: rect.width as i32,
+                    biHeight: -(rect.height as i32), // Negative for top-down
+                    biPlanes: 1,
+                    biBitCount: 32,
+                    biCompression: BI_RGB.0 as u32,
+                    biSizeImage: 0,
+                    biXPelsPerMeter: 0,
+                    biYPelsPerMeter: 0,
+                    biClrUsed: 0,
+                    biClrImportant: 0,
+                },
+                bmiColors: [Default::default()],
+            };
+
+            // Allocate buffer for pixel data
+            let buffer_size = (rect.width * rect.height * 4) as usize;
+            let mut buffer: Vec<u8> = vec![0; buffer_size];
+
+            // Get the bitmap bits
+            let lines = GetDIBits(
+                capture_dc,
+                bitmap,
+                0,
+                rect.height,
+                Some(buffer.as_mut_ptr() as *mut _),
+                &mut bmi,
+                DIB_RGB_COLORS,
+            );
+
+            // Cleanup GDI resources
+            SelectObject(capture_dc, old_bitmap);
+            DeleteObject(bitmap);
+            DeleteDC(capture_dc);
+            ReleaseDC(HWND::default(), screen_dc);
+
+            if lines == 0 {
+                return Err(CaptureError::CaptureFailure(
+                    "GetDIBits failed".to_string(),
+                ));
+            }
+
+            // Convert BGRA to RGBA
+            for chunk in buffer.chunks_exact_mut(4) {
+                chunk.swap(0, 2); // Swap B and R
+            }
+
+            // Create image buffer
+            let image = ImageBuffer::<Rgba<u8>, Vec<u8>>::from_raw(
+                rect.width,
+                rect.height,
+                buffer,
+            )
+            .ok_or_else(|| {
+                CaptureError::CaptureFailure("Failed to create image buffer".to_string())
+            })?;
+
+            Ok(image)
+        }
+    }
+
+    /// Check if screen capture permission is available
+    #[cfg(target_os = "windows")]
+    pub fn check_permission() -> Result<bool, CaptureError> {
+        // Windows generally allows screen capture without special permissions
+        // However, some security software may block it
+        // We'll do a quick test capture to verify
+        unsafe {
+            let screen_dc = GetDC(HWND::default());
+            if screen_dc.is_invalid() {
+                return Err(CaptureError::PermissionDenied);
+            }
+            ReleaseDC(HWND::default(), screen_dc);
+            Ok(true)
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    pub fn check_permission() -> Result<bool, CaptureError> {
+        Err(CaptureError::PlatformNotSupported)
+    }
+}
+
+/// Callback function for EnumDisplayMonitors
+#[cfg(target_os = "windows")]
+unsafe extern "system" fn enum_monitor_callback(
+    monitor: windows::Win32::Graphics::Gdi::HMONITOR,
+    _hdc: HDC,
+    _rect: *mut RECT,
+    lparam: LPARAM,
+) -> BOOL {
+    let monitors = &mut *(lparam.0 as *mut Vec<MonitorInfo>);
+
+    let mut monitor_info = MONITORINFOEXW {
+        monitorInfo: windows::Win32::Graphics::Gdi::MONITORINFO {
+            cbSize: std::mem::size_of::<MONITORINFOEXW>() as u32,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    if GetMonitorInfoW(monitor, &mut monitor_info.monitorInfo).as_bool() {
+        let rect = monitor_info.monitorInfo.rcMonitor;
+        let is_primary = (monitor_info.monitorInfo.dwFlags & 1) != 0; // MONITORINFOF_PRIMARY
+
+        // Get DPI for this monitor
+        let mut dpi_x: u32 = 96;
+        let mut dpi_y: u32 = 96;
+        let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+        let dpi_scale = dpi_x as f64 / 96.0;
+
+        // Get monitor name
+        let name_slice = &monitor_info.szDevice;
+        let name_len = name_slice.iter().position(|&c| c == 0).unwrap_or(name_slice.len());
+        let name = String::from_utf16_lossy(&name_slice[..name_len]);
+
+        monitors.push(MonitorInfo {
+            id: 0, // Will be set later
+            name,
+            x: rect.left,
+            y: rect.top,
+            width: (rect.right - rect.left) as u32,
+            height: (rect.bottom - rect.top) as u32,
+            dpi_scale,
+            is_primary,
+        });
+    }
+
+    TRUE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    // ==================== Monitor Detection Tests ====================
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_get_all_monitors_returns_at_least_one() {
+        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
+        assert!(!monitors.is_empty(), "Should have at least one monitor");
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_monitor_info_contains_valid_dimensions() {
+        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
+
+        for monitor in monitors {
+            assert!(monitor.width > 0, "Monitor width should be positive");
+            assert!(monitor.height > 0, "Monitor height should be positive");
+            assert!(
+                monitor.width <= 8192,
+                "Monitor width should be reasonable (<=8K)"
+            );
+            assert!(
+                monitor.height <= 8192,
+                "Monitor height should be reasonable (<=8K)"
+            );
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_primary_monitor_detected() {
+        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
+        let primary_count = monitors.iter().filter(|m| m.is_primary).count();
+        assert_eq!(primary_count, 1, "Should have exactly one primary monitor");
+    }
+
+    // ==================== DPI Scaling Tests ====================
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_dpi_scale_factor_valid_range() {
+        let scale = ScreenCapture::get_dpi_scale_at_point(0, 0);
+        assert!(scale >= 1.0, "DPI scale should be at least 1.0");
+        assert!(scale <= 4.0, "DPI scale should be at most 4.0 (400%)");
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_100_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::apply_dpi_scaling(rect, 1.0);
+
+        assert_eq!(scaled.x, 100);
+        assert_eq!(scaled.y, 200);
+        assert_eq!(scaled.width, 300);
+        assert_eq!(scaled.height, 400);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_150_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::apply_dpi_scaling(rect, 1.5);
+
+        assert_eq!(scaled.x, 150);
+        assert_eq!(scaled.y, 300);
+        assert_eq!(scaled.width, 450);
+        assert_eq!(scaled.height, 600);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_200_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::apply_dpi_scaling(rect, 2.0);
+
+        assert_eq!(scaled.x, 200);
+        assert_eq!(scaled.y, 400);
+        assert_eq!(scaled.width, 600);
+        assert_eq!(scaled.height, 800);
+    }
+
+    // ==================== Coordinate Translation Tests ====================
+
+    #[test]
+    fn test_rect_from_points_top_left_to_bottom_right() {
+        let rect = Rect::from_points(10, 20, 110, 220);
+        assert_eq!(rect.x, 10);
+        assert_eq!(rect.y, 20);
+        assert_eq!(rect.width, 100);
+        assert_eq!(rect.height, 200);
+    }
+
+    #[test]
+    fn test_rect_from_points_bottom_right_to_top_left() {
+        let rect = Rect::from_points(110, 220, 10, 20);
+        assert_eq!(rect.x, 10);
+        assert_eq!(rect.y, 20);
+        assert_eq!(rect.width, 100);
+        assert_eq!(rect.height, 200);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_virtual_screen_bounds_valid() {
+        let bounds = ScreenCapture::get_virtual_screen_bounds();
+        assert!(bounds.width > 0, "Virtual screen width should be positive");
+        assert!(bounds.height > 0, "Virtual screen height should be positive");
+    }
+
+    // ==================== Validation Tests ====================
+
+    #[test]
+    fn test_validate_selection_minimum_size_pass() {
+        let rect = Rect::new(0, 0, 10, 10);
+        let result = ScreenCapture::validate_selection(rect);
+        assert!(result.is_ok(), "10x10 selection should be valid");
+    }
+
+    #[test]
+    fn test_validate_selection_9x9_rejected() {
+        let rect = Rect::new(0, 0, 9, 9);
+        let result = ScreenCapture::validate_selection(rect);
+        assert!(
+            matches!(result, Err(CaptureError::SelectionTooSmall)),
+            "9x9 selection should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_selection_10x9_rejected() {
+        let rect = Rect::new(0, 0, 10, 9);
+        let result = ScreenCapture::validate_selection(rect);
+        assert!(
+            matches!(result, Err(CaptureError::SelectionTooSmall)),
+            "10x9 selection should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_validate_selection_9x10_rejected() {
+        let rect = Rect::new(0, 0, 9, 10);
+        let result = ScreenCapture::validate_selection(rect);
+        assert!(
+            matches!(result, Err(CaptureError::SelectionTooSmall)),
+            "9x10 selection should be rejected"
+        );
+    }
+
+    #[test]
+    fn test_clamp_rect_extends_past_right_edge() {
+        let rect = Rect::new(900, 0, 200, 100);
+        let bounds = Rect::new(0, 0, 1000, 1000);
+        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+
+        assert_eq!(clamped.x, 900);
+        assert_eq!(clamped.width, 100, "Should clamp width to screen boundary");
+    }
+
+    #[test]
+    fn test_clamp_rect_extends_past_bottom_edge() {
+        let rect = Rect::new(0, 900, 100, 200);
+        let bounds = Rect::new(0, 0, 1000, 1000);
+        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+
+        assert_eq!(clamped.y, 900);
+        assert_eq!(clamped.height, 100, "Should clamp height to screen boundary");
+    }
+
+    #[test]
+    fn test_clamp_rect_negative_x_clamped() {
+        let rect = Rect::new(-50, 0, 100, 100);
+        let bounds = Rect::new(0, 0, 1000, 1000);
+        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+
+        assert_eq!(clamped.x, 0, "Negative x should be clamped to 0");
+    }
+
+    #[test]
+    fn test_clamp_rect_negative_y_clamped() {
+        let rect = Rect::new(0, -50, 100, 100);
+        let bounds = Rect::new(0, 0, 1000, 1000);
+        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+
+        assert_eq!(clamped.y, 0, "Negative y should be clamped to 0");
+    }
+
+    // ==================== Screen Capture Tests ====================
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_capture_region_creates_valid_png() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+
+        let rect = Rect::new(0, 0, 100, 100);
+        let result = capture.capture_region(rect);
+
+        assert!(result.is_ok(), "Capture should succeed");
+
+        let capture_result = result.unwrap();
+        let path = std::path::Path::new(&capture_result.file_path);
+        assert!(path.exists(), "Captured file should exist");
+        assert!(
+            path.extension().map_or(false, |ext| ext == "png"),
+            "File should be PNG"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_capture_region_correct_dimensions() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+
+        let rect = Rect::new(0, 0, 200, 150);
+        let result = capture.capture_region(rect).expect("Capture should succeed");
+
+        // Load the image and verify dimensions
+        let img = image::open(&result.file_path).expect("Should load captured image");
+
+        // Note: actual dimensions may differ due to DPI scaling
+        // We just verify the image is loadable and has reasonable dimensions
+        assert!(img.width() > 0);
+        assert!(img.height() > 0);
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_capture_saves_to_temp_directory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let temp_path = temp_dir.path().to_path_buf();
+        let capture = ScreenCapture::new(temp_path.clone());
+
+        let rect = Rect::new(0, 0, 50, 50);
+        let result = capture.capture_region(rect).expect("Capture should succeed");
+
+        assert!(
+            result.file_path.starts_with(&temp_path.to_string_lossy().to_string()),
+            "File should be in temp directory"
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_capture_unique_filename_generation() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+
+        let rect = Rect::new(0, 0, 20, 20);
+
+        let result1 = capture.capture_region(rect).expect("First capture should succeed");
+        let result2 = capture.capture_region(rect).expect("Second capture should succeed");
+
+        assert_ne!(
+            result1.file_path, result2.file_path,
+            "Each capture should have unique filename"
+        );
+    }
+
+    // ==================== Permission Tests ====================
+
+    #[test]
+    #[cfg(target_os = "windows")]
+    fn test_permission_check_returns_result() {
+        let result = ScreenCapture::check_permission();
+        // Should return Ok(true) or an error, but not panic
+        assert!(result.is_ok() || result.is_err());
+    }
+
+    // ==================== Error Type Tests ====================
+
+    #[test]
+    fn test_capture_error_display() {
+        let error = CaptureError::SelectionTooSmall;
+        let msg = format!("{}", error);
+        assert!(
+            msg.contains("10x10"),
+            "Error message should mention minimum size"
+        );
+    }
+
+    #[test]
+    fn test_rect_is_valid_size() {
+        assert!(Rect::new(0, 0, 10, 10).is_valid_size(10, 10));
+        assert!(Rect::new(0, 0, 100, 100).is_valid_size(10, 10));
+        assert!(!Rect::new(0, 0, 9, 10).is_valid_size(10, 10));
+        assert!(!Rect::new(0, 0, 10, 9).is_valid_size(10, 10));
+    }
+}

--- a/wrapper/src-tauri/src/capture.rs
+++ b/wrapper/src-tauri/src/capture.rs
@@ -1,27 +1,12 @@
-//! Screen capture module for Windows platform
+//! Screen capture module with platform abstraction for testability
 //! Handles monitor detection, DPI scaling, and screen region capture
 
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use image::{ImageBuffer, Rgba};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use thiserror::Error;
 use tracing::{debug, error, info};
-
-#[cfg(target_os = "windows")]
-use windows::{
-    Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT, TRUE},
-    Win32::Graphics::Gdi::{
-        BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
-        GetDC, GetDIBits, ReleaseDC, SelectObject, BITMAPINFO, BITMAPINFOHEADER,
-        BI_RGB, DIB_RGB_COLORS, HBITMAP, HDC, SRCCOPY,
-    },
-    Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
-    Win32::UI::WindowsAndMessaging::{
-        EnumDisplayMonitors, GetMonitorInfoW, GetSystemMetrics, MONITORINFOEXW,
-        SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
-    },
-};
 
 /// Errors that can occur during screen capture operations
 #[derive(Error, Debug)]
@@ -99,88 +84,425 @@ pub struct CaptureResult {
     pub timestamp: String,
 }
 
-/// Main screen capture manager
-pub struct ScreenCapture {
-    temp_dir: PathBuf,
+// ==================== Platform Abstraction Trait ====================
+
+/// Trait for platform-specific screen operations
+/// This allows mocking for tests on any platform
+pub trait ScreenBackend: Send + Sync {
+    /// Get all connected monitors
+    fn get_monitors(&self) -> Result<Vec<MonitorInfo>, CaptureError>;
+
+    /// Get the virtual screen bounds (encompasses all monitors)
+    fn get_virtual_screen_bounds(&self) -> Rect;
+
+    /// Get DPI scale factor at a specific point
+    fn get_dpi_scale_at_point(&self, x: i32, y: i32) -> f64;
+
+    /// Capture a region of the screen as RGBA pixels
+    fn capture_region_pixels(&self, rect: Rect) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError>;
+
+    /// Check if screen capture permission is available
+    fn check_permission(&self) -> Result<bool, CaptureError>;
 }
 
-impl ScreenCapture {
-    /// Create a new ScreenCapture instance
-    pub fn new(temp_dir: PathBuf) -> Self {
-        Self { temp_dir }
+// ==================== Windows Implementation ====================
+
+#[cfg(target_os = "windows")]
+mod windows_backend {
+    use super::*;
+    use windows::{
+        Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT, TRUE},
+        Win32::Graphics::Gdi::{
+            BitBlt, CreateCompatibleBitmap, CreateCompatibleDC, DeleteDC, DeleteObject,
+            GetDC, GetDIBits, MonitorFromPoint, ReleaseDC, SelectObject, BITMAPINFO,
+            BITMAPINFOHEADER, BI_RGB, DIB_RGB_COLORS, HDC, MONITOR_DEFAULTTONEAREST, SRCCOPY,
+        },
+        Win32::UI::HiDpi::{GetDpiForMonitor, MDT_EFFECTIVE_DPI},
+        Win32::UI::WindowsAndMessaging::{
+            EnumDisplayMonitors, GetMonitorInfoW, GetSystemMetrics, MONITORINFOEXW,
+            SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+        },
+    };
+
+    pub struct WindowsScreenBackend;
+
+    impl WindowsScreenBackend {
+        pub fn new() -> Self {
+            Self
+        }
     }
 
-    /// Get information about all connected monitors
-    #[cfg(target_os = "windows")]
-    pub fn get_monitors() -> Result<Vec<MonitorInfo>, CaptureError> {
-        let mut monitors: Vec<MonitorInfo> = Vec::new();
-        let monitors_ptr = &mut monitors as *mut Vec<MonitorInfo>;
+    impl ScreenBackend for WindowsScreenBackend {
+        fn get_monitors(&self) -> Result<Vec<MonitorInfo>, CaptureError> {
+            let mut monitors: Vec<MonitorInfo> = Vec::new();
+            let monitors_ptr = &mut monitors as *mut Vec<MonitorInfo>;
 
-        unsafe {
-            let result = EnumDisplayMonitors(
-                HDC::default(),
-                None,
-                Some(enum_monitor_callback),
-                LPARAM(monitors_ptr as isize),
-            );
+            unsafe {
+                let result = EnumDisplayMonitors(
+                    HDC::default(),
+                    None,
+                    Some(enum_monitor_callback),
+                    LPARAM(monitors_ptr as isize),
+                );
 
-            if !result.as_bool() {
-                return Err(CaptureError::CaptureFailure(
-                    "Failed to enumerate monitors".to_string(),
-                ));
+                if !result.as_bool() {
+                    return Err(CaptureError::CaptureFailure(
+                        "Failed to enumerate monitors".to_string(),
+                    ));
+                }
+            }
+
+            if monitors.is_empty() {
+                return Err(CaptureError::NoMonitors);
+            }
+
+            // Assign IDs
+            for (i, monitor) in monitors.iter_mut().enumerate() {
+                monitor.id = i as u32;
+            }
+
+            debug!("Detected {} monitors", monitors.len());
+            Ok(monitors)
+        }
+
+        fn get_virtual_screen_bounds(&self) -> Rect {
+            unsafe {
+                let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
+                let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
+                let width = GetSystemMetrics(SM_CXVIRTUALSCREEN) as u32;
+                let height = GetSystemMetrics(SM_CYVIRTUALSCREEN) as u32;
+
+                debug!(
+                    "Virtual screen bounds: x={}, y={}, width={}, height={}",
+                    x, y, width, height
+                );
+
+                Rect::new(x, y, width, height)
             }
         }
 
-        if monitors.is_empty() {
-            return Err(CaptureError::NoMonitors);
+        fn get_dpi_scale_at_point(&self, x: i32, y: i32) -> f64 {
+            unsafe {
+                let point = POINT { x, y };
+                let monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
+
+                let mut dpi_x: u32 = 96;
+                let mut dpi_y: u32 = 96;
+
+                let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+
+                dpi_x as f64 / 96.0
+            }
         }
 
-        // Assign IDs
-        for (i, monitor) in monitors.iter_mut().enumerate() {
-            monitor.id = i as u32;
+        fn capture_region_pixels(&self, rect: Rect) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
+            unsafe {
+                // Get screen device context
+                let screen_dc = GetDC(HWND::default());
+                if screen_dc.is_invalid() {
+                    return Err(CaptureError::CaptureFailure(
+                        "Failed to get screen DC".to_string(),
+                    ));
+                }
+
+                // Create compatible DC for the capture
+                let capture_dc = CreateCompatibleDC(screen_dc);
+                if capture_dc.is_invalid() {
+                    ReleaseDC(HWND::default(), screen_dc);
+                    return Err(CaptureError::CaptureFailure(
+                        "Failed to create compatible DC".to_string(),
+                    ));
+                }
+
+                // Create compatible bitmap
+                let bitmap = CreateCompatibleBitmap(screen_dc, rect.width as i32, rect.height as i32);
+                if bitmap.is_invalid() {
+                    DeleteDC(capture_dc);
+                    ReleaseDC(HWND::default(), screen_dc);
+                    return Err(CaptureError::CaptureFailure(
+                        "Failed to create bitmap".to_string(),
+                    ));
+                }
+
+                // Select bitmap into DC
+                let old_bitmap = SelectObject(capture_dc, bitmap);
+
+                // Copy screen region to bitmap
+                let result = BitBlt(
+                    capture_dc,
+                    0,
+                    0,
+                    rect.width as i32,
+                    rect.height as i32,
+                    screen_dc,
+                    rect.x,
+                    rect.y,
+                    SRCCOPY,
+                );
+
+                if !result.as_bool() {
+                    SelectObject(capture_dc, old_bitmap);
+                    DeleteObject(bitmap);
+                    DeleteDC(capture_dc);
+                    ReleaseDC(HWND::default(), screen_dc);
+                    return Err(CaptureError::CaptureFailure("BitBlt failed".to_string()));
+                }
+
+                // Prepare bitmap info header for extraction
+                let mut bmi = BITMAPINFO {
+                    bmiHeader: BITMAPINFOHEADER {
+                        biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
+                        biWidth: rect.width as i32,
+                        biHeight: -(rect.height as i32), // Negative for top-down
+                        biPlanes: 1,
+                        biBitCount: 32,
+                        biCompression: BI_RGB.0 as u32,
+                        biSizeImage: 0,
+                        biXPelsPerMeter: 0,
+                        biYPelsPerMeter: 0,
+                        biClrUsed: 0,
+                        biClrImportant: 0,
+                    },
+                    bmiColors: [Default::default()],
+                };
+
+                // Allocate buffer for pixel data
+                let buffer_size = (rect.width * rect.height * 4) as usize;
+                let mut buffer: Vec<u8> = vec![0; buffer_size];
+
+                // Get the bitmap bits
+                let lines = GetDIBits(
+                    capture_dc,
+                    bitmap,
+                    0,
+                    rect.height,
+                    Some(buffer.as_mut_ptr() as *mut _),
+                    &mut bmi,
+                    DIB_RGB_COLORS,
+                );
+
+                // Cleanup GDI resources
+                SelectObject(capture_dc, old_bitmap);
+                DeleteObject(bitmap);
+                DeleteDC(capture_dc);
+                ReleaseDC(HWND::default(), screen_dc);
+
+                if lines == 0 {
+                    return Err(CaptureError::CaptureFailure("GetDIBits failed".to_string()));
+                }
+
+                // Convert BGRA to RGBA
+                for chunk in buffer.chunks_exact_mut(4) {
+                    chunk.swap(0, 2); // Swap B and R
+                }
+
+                // Create image buffer
+                let image = ImageBuffer::<Rgba<u8>, Vec<u8>>::from_raw(rect.width, rect.height, buffer)
+                    .ok_or_else(|| {
+                        CaptureError::CaptureFailure("Failed to create image buffer".to_string())
+                    })?;
+
+                Ok(image)
+            }
         }
 
-        debug!("Detected {} monitors", monitors.len());
-        Ok(monitors)
+        fn check_permission(&self) -> Result<bool, CaptureError> {
+            unsafe {
+                let screen_dc = GetDC(HWND::default());
+                if screen_dc.is_invalid() {
+                    return Err(CaptureError::PermissionDenied);
+                }
+                ReleaseDC(HWND::default(), screen_dc);
+                Ok(true)
+            }
+        }
     }
 
-    #[cfg(not(target_os = "windows"))]
-    pub fn get_monitors() -> Result<Vec<MonitorInfo>, CaptureError> {
-        Err(CaptureError::PlatformNotSupported)
+    /// Callback function for EnumDisplayMonitors
+    unsafe extern "system" fn enum_monitor_callback(
+        monitor: windows::Win32::Graphics::Gdi::HMONITOR,
+        _hdc: HDC,
+        _rect: *mut RECT,
+        lparam: LPARAM,
+    ) -> BOOL {
+        let monitors = &mut *(lparam.0 as *mut Vec<MonitorInfo>);
+
+        let mut monitor_info = MONITORINFOEXW {
+            monitorInfo: windows::Win32::Graphics::Gdi::MONITORINFO {
+                cbSize: std::mem::size_of::<MONITORINFOEXW>() as u32,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        if GetMonitorInfoW(monitor, &mut monitor_info.monitorInfo).as_bool() {
+            let rect = monitor_info.monitorInfo.rcMonitor;
+            let is_primary = (monitor_info.monitorInfo.dwFlags & 1) != 0;
+
+            // Get DPI for this monitor
+            let mut dpi_x: u32 = 96;
+            let mut dpi_y: u32 = 96;
+            let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
+            let dpi_scale = dpi_x as f64 / 96.0;
+
+            // Get monitor name
+            let name_slice = &monitor_info.szDevice;
+            let name_len = name_slice.iter().position(|&c| c == 0).unwrap_or(name_slice.len());
+            let name = String::from_utf16_lossy(&name_slice[..name_len]);
+
+            monitors.push(MonitorInfo {
+                id: 0,
+                name,
+                x: rect.left,
+                y: rect.top,
+                width: (rect.right - rect.left) as u32,
+                height: (rect.bottom - rect.top) as u32,
+                dpi_scale,
+                is_primary,
+            });
+        }
+
+        TRUE
+    }
+}
+
+// ==================== Mock Implementation for Testing ====================
+
+/// Mock backend for testing on any platform
+pub struct MockScreenBackend {
+    pub monitors: Vec<MonitorInfo>,
+    pub virtual_bounds: Rect,
+    pub dpi_scale: f64,
+    pub capture_result: Option<ImageBuffer<Rgba<u8>, Vec<u8>>>,
+    pub permission_granted: bool,
+}
+
+impl Default for MockScreenBackend {
+    fn default() -> Self {
+        Self {
+            monitors: vec![MonitorInfo {
+                id: 0,
+                name: "Mock Monitor".to_string(),
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                dpi_scale: 1.0,
+                is_primary: true,
+            }],
+            virtual_bounds: Rect::new(0, 0, 1920, 1080),
+            dpi_scale: 1.0,
+            capture_result: None,
+            permission_granted: true,
+        }
+    }
+}
+
+impl MockScreenBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_monitors(mut self, monitors: Vec<MonitorInfo>) -> Self {
+        self.monitors = monitors;
+        self
+    }
+
+    pub fn with_virtual_bounds(mut self, bounds: Rect) -> Self {
+        self.virtual_bounds = bounds;
+        self
+    }
+
+    pub fn with_dpi_scale(mut self, scale: f64) -> Self {
+        self.dpi_scale = scale;
+        self
+    }
+
+    pub fn with_permission(mut self, granted: bool) -> Self {
+        self.permission_granted = granted;
+        self
+    }
+
+    /// Create a test image of specified dimensions
+    pub fn create_test_image(width: u32, height: u32) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
+        ImageBuffer::from_fn(width, height, |x, y| {
+            // Create a simple gradient pattern for testing
+            Rgba([
+                (x % 256) as u8,
+                (y % 256) as u8,
+                ((x + y) % 256) as u8,
+                255,
+            ])
+        })
+    }
+}
+
+impl ScreenBackend for MockScreenBackend {
+    fn get_monitors(&self) -> Result<Vec<MonitorInfo>, CaptureError> {
+        if self.monitors.is_empty() {
+            Err(CaptureError::NoMonitors)
+        } else {
+            Ok(self.monitors.clone())
+        }
+    }
+
+    fn get_virtual_screen_bounds(&self) -> Rect {
+        self.virtual_bounds
+    }
+
+    fn get_dpi_scale_at_point(&self, _x: i32, _y: i32) -> f64 {
+        self.dpi_scale
+    }
+
+    fn capture_region_pixels(&self, rect: Rect) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
+        match &self.capture_result {
+            Some(img) => Ok(img.clone()),
+            None => Ok(Self::create_test_image(rect.width, rect.height)),
+        }
+    }
+
+    fn check_permission(&self) -> Result<bool, CaptureError> {
+        if self.permission_granted {
+            Ok(true)
+        } else {
+            Err(CaptureError::PermissionDenied)
+        }
+    }
+}
+
+// ==================== Main Screen Capture Implementation ====================
+
+/// Main screen capture manager - uses backend abstraction
+pub struct ScreenCapture<B: ScreenBackend> {
+    backend: B,
+    temp_dir: PathBuf,
+}
+
+impl<B: ScreenBackend> ScreenCapture<B> {
+    /// Create a new ScreenCapture with a specific backend
+    pub fn with_backend(backend: B, temp_dir: PathBuf) -> Self {
+        Self { backend, temp_dir }
+    }
+
+    /// Get information about all connected monitors
+    pub fn get_monitors(&self) -> Result<Vec<MonitorInfo>, CaptureError> {
+        self.backend.get_monitors()
     }
 
     /// Get the virtual screen bounds (encompasses all monitors)
-    #[cfg(target_os = "windows")]
-    pub fn get_virtual_screen_bounds() -> Rect {
-        unsafe {
-            let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
-            let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
-            let width = GetSystemMetrics(SM_CXVIRTUALSCREEN) as u32;
-            let height = GetSystemMetrics(SM_CYVIRTUALSCREEN) as u32;
-
-            debug!(
-                "Virtual screen bounds: x={}, y={}, width={}, height={}",
-                x, y, width, height
-            );
-
-            Rect::new(x, y, width, height)
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    pub fn get_virtual_screen_bounds() -> Rect {
-        Rect::new(0, 0, 1920, 1080) // Default fallback
+    pub fn get_virtual_screen_bounds(&self) -> Rect {
+        self.backend.get_virtual_screen_bounds()
     }
 
     /// Validate and adjust a selection rectangle
-    pub fn validate_selection(rect: Rect) -> Result<Rect, CaptureError> {
+    pub fn validate_selection(&self, rect: Rect) -> Result<Rect, CaptureError> {
         // Check minimum size
         if !rect.is_valid_size(10, 10) {
             return Err(CaptureError::SelectionTooSmall);
         }
 
         // Clamp to screen boundaries
-        let bounds = Self::get_virtual_screen_bounds();
+        let bounds = self.get_virtual_screen_bounds();
         let clamped = Self::clamp_rect_to_bounds(rect, bounds);
 
         Ok(clamped)
@@ -210,32 +532,7 @@ impl ScreenCapture {
         )
     }
 
-    /// Get DPI scale factor for a specific point on screen
-    #[cfg(target_os = "windows")]
-    pub fn get_dpi_scale_at_point(x: i32, y: i32) -> f64 {
-        use windows::Win32::Graphics::Gdi::MonitorFromPoint;
-        use windows::Win32::Graphics::Gdi::MONITOR_DEFAULTTONEAREST;
-
-        unsafe {
-            let point = POINT { x, y };
-            let monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
-
-            let mut dpi_x: u32 = 96;
-            let mut dpi_y: u32 = 96;
-
-            let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
-
-            dpi_x as f64 / 96.0
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    pub fn get_dpi_scale_at_point(_x: i32, _y: i32) -> f64 {
-        1.0
-    }
-
     /// Capture a region of the screen and save to file
-    #[cfg(target_os = "windows")]
     pub fn capture_region(&self, rect: Rect) -> Result<CaptureResult, CaptureError> {
         info!(
             "Capturing region: x={}, y={}, width={}, height={}",
@@ -243,17 +540,17 @@ impl ScreenCapture {
         );
 
         // Validate the selection
-        let validated_rect = Self::validate_selection(rect)?;
+        let validated_rect = self.validate_selection(rect)?;
 
         // Get DPI scale for the capture area
-        let dpi_scale = Self::get_dpi_scale_at_point(validated_rect.x, validated_rect.y);
+        let dpi_scale = self.backend.get_dpi_scale_at_point(validated_rect.x, validated_rect.y);
         debug!("DPI scale factor: {}", dpi_scale);
 
         // Apply DPI scaling to get physical pixel coordinates
         let physical_rect = Self::apply_dpi_scaling(validated_rect, dpi_scale);
 
         // Capture the screen region
-        let image_data = self.capture_screen_region_internal(physical_rect)?;
+        let image_data = self.backend.capture_region_pixels(physical_rect)?;
 
         // Generate unique filename
         let timestamp = chrono::Local::now();
@@ -285,290 +582,62 @@ impl ScreenCapture {
         })
     }
 
-    #[cfg(not(target_os = "windows"))]
-    pub fn capture_region(&self, _rect: Rect) -> Result<CaptureResult, CaptureError> {
-        Err(CaptureError::PlatformNotSupported)
-    }
-
-    /// Internal function to capture screen pixels using Windows GDI
-    #[cfg(target_os = "windows")]
-    fn capture_screen_region_internal(
-        &self,
-        rect: Rect,
-    ) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
-        unsafe {
-            // Get screen device context
-            let screen_dc = GetDC(HWND::default());
-            if screen_dc.is_invalid() {
-                return Err(CaptureError::CaptureFailure(
-                    "Failed to get screen DC".to_string(),
-                ));
-            }
-
-            // Create compatible DC for the capture
-            let capture_dc = CreateCompatibleDC(screen_dc);
-            if capture_dc.is_invalid() {
-                ReleaseDC(HWND::default(), screen_dc);
-                return Err(CaptureError::CaptureFailure(
-                    "Failed to create compatible DC".to_string(),
-                ));
-            }
-
-            // Create compatible bitmap
-            let bitmap = CreateCompatibleBitmap(screen_dc, rect.width as i32, rect.height as i32);
-            if bitmap.is_invalid() {
-                DeleteDC(capture_dc);
-                ReleaseDC(HWND::default(), screen_dc);
-                return Err(CaptureError::CaptureFailure(
-                    "Failed to create bitmap".to_string(),
-                ));
-            }
-
-            // Select bitmap into DC
-            let old_bitmap = SelectObject(capture_dc, bitmap);
-
-            // Copy screen region to bitmap
-            let result = BitBlt(
-                capture_dc,
-                0,
-                0,
-                rect.width as i32,
-                rect.height as i32,
-                screen_dc,
-                rect.x,
-                rect.y,
-                SRCCOPY,
-            );
-
-            if !result.as_bool() {
-                SelectObject(capture_dc, old_bitmap);
-                DeleteObject(bitmap);
-                DeleteDC(capture_dc);
-                ReleaseDC(HWND::default(), screen_dc);
-                return Err(CaptureError::CaptureFailure(
-                    "BitBlt failed".to_string(),
-                ));
-            }
-
-            // Prepare bitmap info header for extraction
-            let mut bmi = BITMAPINFO {
-                bmiHeader: BITMAPINFOHEADER {
-                    biSize: std::mem::size_of::<BITMAPINFOHEADER>() as u32,
-                    biWidth: rect.width as i32,
-                    biHeight: -(rect.height as i32), // Negative for top-down
-                    biPlanes: 1,
-                    biBitCount: 32,
-                    biCompression: BI_RGB.0 as u32,
-                    biSizeImage: 0,
-                    biXPelsPerMeter: 0,
-                    biYPelsPerMeter: 0,
-                    biClrUsed: 0,
-                    biClrImportant: 0,
-                },
-                bmiColors: [Default::default()],
-            };
-
-            // Allocate buffer for pixel data
-            let buffer_size = (rect.width * rect.height * 4) as usize;
-            let mut buffer: Vec<u8> = vec![0; buffer_size];
-
-            // Get the bitmap bits
-            let lines = GetDIBits(
-                capture_dc,
-                bitmap,
-                0,
-                rect.height,
-                Some(buffer.as_mut_ptr() as *mut _),
-                &mut bmi,
-                DIB_RGB_COLORS,
-            );
-
-            // Cleanup GDI resources
-            SelectObject(capture_dc, old_bitmap);
-            DeleteObject(bitmap);
-            DeleteDC(capture_dc);
-            ReleaseDC(HWND::default(), screen_dc);
-
-            if lines == 0 {
-                return Err(CaptureError::CaptureFailure(
-                    "GetDIBits failed".to_string(),
-                ));
-            }
-
-            // Convert BGRA to RGBA
-            for chunk in buffer.chunks_exact_mut(4) {
-                chunk.swap(0, 2); // Swap B and R
-            }
-
-            // Create image buffer
-            let image = ImageBuffer::<Rgba<u8>, Vec<u8>>::from_raw(
-                rect.width,
-                rect.height,
-                buffer,
-            )
-            .ok_or_else(|| {
-                CaptureError::CaptureFailure("Failed to create image buffer".to_string())
-            })?;
-
-            Ok(image)
-        }
-    }
-
     /// Check if screen capture permission is available
-    #[cfg(target_os = "windows")]
-    pub fn check_permission() -> Result<bool, CaptureError> {
-        // Windows generally allows screen capture without special permissions
-        // However, some security software may block it
-        // We'll do a quick test capture to verify
-        unsafe {
-            let screen_dc = GetDC(HWND::default());
-            if screen_dc.is_invalid() {
-                return Err(CaptureError::PermissionDenied);
-            }
-            ReleaseDC(HWND::default(), screen_dc);
-            Ok(true)
-        }
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    pub fn check_permission() -> Result<bool, CaptureError> {
-        Err(CaptureError::PlatformNotSupported)
+    pub fn check_permission(&self) -> Result<bool, CaptureError> {
+        self.backend.check_permission()
     }
 }
 
-/// Callback function for EnumDisplayMonitors
+// ==================== Convenience Functions for Production Use ====================
+
+/// Create a ScreenCapture with the platform-specific backend
 #[cfg(target_os = "windows")]
-unsafe extern "system" fn enum_monitor_callback(
-    monitor: windows::Win32::Graphics::Gdi::HMONITOR,
-    _hdc: HDC,
-    _rect: *mut RECT,
-    lparam: LPARAM,
-) -> BOOL {
-    let monitors = &mut *(lparam.0 as *mut Vec<MonitorInfo>);
-
-    let mut monitor_info = MONITORINFOEXW {
-        monitorInfo: windows::Win32::Graphics::Gdi::MONITORINFO {
-            cbSize: std::mem::size_of::<MONITORINFOEXW>() as u32,
-            ..Default::default()
-        },
-        ..Default::default()
-    };
-
-    if GetMonitorInfoW(monitor, &mut monitor_info.monitorInfo).as_bool() {
-        let rect = monitor_info.monitorInfo.rcMonitor;
-        let is_primary = (monitor_info.monitorInfo.dwFlags & 1) != 0; // MONITORINFOF_PRIMARY
-
-        // Get DPI for this monitor
-        let mut dpi_x: u32 = 96;
-        let mut dpi_y: u32 = 96;
-        let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
-        let dpi_scale = dpi_x as f64 / 96.0;
-
-        // Get monitor name
-        let name_slice = &monitor_info.szDevice;
-        let name_len = name_slice.iter().position(|&c| c == 0).unwrap_or(name_slice.len());
-        let name = String::from_utf16_lossy(&name_slice[..name_len]);
-
-        monitors.push(MonitorInfo {
-            id: 0, // Will be set later
-            name,
-            x: rect.left,
-            y: rect.top,
-            width: (rect.right - rect.left) as u32,
-            height: (rect.bottom - rect.top) as u32,
-            dpi_scale,
-            is_primary,
-        });
-    }
-
-    TRUE
+pub fn create_screen_capture(temp_dir: PathBuf) -> ScreenCapture<windows_backend::WindowsScreenBackend> {
+    ScreenCapture::with_backend(windows_backend::WindowsScreenBackend::new(), temp_dir)
 }
+
+/// Get monitors using platform-specific backend
+#[cfg(target_os = "windows")]
+pub fn get_monitors_native() -> Result<Vec<MonitorInfo>, CaptureError> {
+    windows_backend::WindowsScreenBackend::new().get_monitors()
+}
+
+/// Get virtual screen bounds using platform-specific backend
+#[cfg(target_os = "windows")]
+pub fn get_virtual_screen_bounds_native() -> Rect {
+    windows_backend::WindowsScreenBackend::new().get_virtual_screen_bounds()
+}
+
+/// Check permission using platform-specific backend
+#[cfg(target_os = "windows")]
+pub fn check_permission_native() -> Result<bool, CaptureError> {
+    windows_backend::WindowsScreenBackend::new().check_permission()
+}
+
+// Non-Windows fallbacks that return errors
+#[cfg(not(target_os = "windows"))]
+pub fn get_monitors_native() -> Result<Vec<MonitorInfo>, CaptureError> {
+    Err(CaptureError::PlatformNotSupported)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn get_virtual_screen_bounds_native() -> Rect {
+    Rect::new(0, 0, 1920, 1080) // Default fallback
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn check_permission_native() -> Result<bool, CaptureError> {
+    Err(CaptureError::PlatformNotSupported)
+}
+
+// ==================== Tests ====================
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    // ==================== Monitor Detection Tests ====================
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_get_all_monitors_returns_at_least_one() {
-        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
-        assert!(!monitors.is_empty(), "Should have at least one monitor");
-    }
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_monitor_info_contains_valid_dimensions() {
-        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
-
-        for monitor in monitors {
-            assert!(monitor.width > 0, "Monitor width should be positive");
-            assert!(monitor.height > 0, "Monitor height should be positive");
-            assert!(
-                monitor.width <= 8192,
-                "Monitor width should be reasonable (<=8K)"
-            );
-            assert!(
-                monitor.height <= 8192,
-                "Monitor height should be reasonable (<=8K)"
-            );
-        }
-    }
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_primary_monitor_detected() {
-        let monitors = ScreenCapture::get_monitors().expect("Should detect monitors");
-        let primary_count = monitors.iter().filter(|m| m.is_primary).count();
-        assert_eq!(primary_count, 1, "Should have exactly one primary monitor");
-    }
-
-    // ==================== DPI Scaling Tests ====================
-
-    #[test]
-    #[cfg(target_os = "windows")]
-    fn test_dpi_scale_factor_valid_range() {
-        let scale = ScreenCapture::get_dpi_scale_at_point(0, 0);
-        assert!(scale >= 1.0, "DPI scale should be at least 1.0");
-        assert!(scale <= 4.0, "DPI scale should be at most 4.0 (400%)");
-    }
-
-    #[test]
-    fn test_apply_dpi_scaling_100_percent() {
-        let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::apply_dpi_scaling(rect, 1.0);
-
-        assert_eq!(scaled.x, 100);
-        assert_eq!(scaled.y, 200);
-        assert_eq!(scaled.width, 300);
-        assert_eq!(scaled.height, 400);
-    }
-
-    #[test]
-    fn test_apply_dpi_scaling_150_percent() {
-        let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::apply_dpi_scaling(rect, 1.5);
-
-        assert_eq!(scaled.x, 150);
-        assert_eq!(scaled.y, 300);
-        assert_eq!(scaled.width, 450);
-        assert_eq!(scaled.height, 600);
-    }
-
-    #[test]
-    fn test_apply_dpi_scaling_200_percent() {
-        let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::apply_dpi_scaling(rect, 2.0);
-
-        assert_eq!(scaled.x, 200);
-        assert_eq!(scaled.y, 400);
-        assert_eq!(scaled.width, 600);
-        assert_eq!(scaled.height, 800);
-    }
-
-    // ==================== Coordinate Translation Tests ====================
+    // ==================== Rect Tests ====================
 
     #[test]
     fn test_rect_from_points_top_left_to_bottom_right() {
@@ -589,26 +658,78 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "windows")]
-    fn test_virtual_screen_bounds_valid() {
-        let bounds = ScreenCapture::get_virtual_screen_bounds();
-        assert!(bounds.width > 0, "Virtual screen width should be positive");
-        assert!(bounds.height > 0, "Virtual screen height should be positive");
+    fn test_rect_is_valid_size() {
+        assert!(Rect::new(0, 0, 10, 10).is_valid_size(10, 10));
+        assert!(Rect::new(0, 0, 100, 100).is_valid_size(10, 10));
+        assert!(!Rect::new(0, 0, 9, 10).is_valid_size(10, 10));
+        assert!(!Rect::new(0, 0, 10, 9).is_valid_size(10, 10));
+    }
+
+    // ==================== DPI Scaling Tests ====================
+
+    #[test]
+    fn test_apply_dpi_scaling_100_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.0);
+
+        assert_eq!(scaled.x, 100);
+        assert_eq!(scaled.y, 200);
+        assert_eq!(scaled.width, 300);
+        assert_eq!(scaled.height, 400);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_150_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.5);
+
+        assert_eq!(scaled.x, 150);
+        assert_eq!(scaled.y, 300);
+        assert_eq!(scaled.width, 450);
+        assert_eq!(scaled.height, 600);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_200_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 2.0);
+
+        assert_eq!(scaled.x, 200);
+        assert_eq!(scaled.y, 400);
+        assert_eq!(scaled.width, 600);
+        assert_eq!(scaled.height, 800);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_125_percent() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.25);
+
+        assert_eq!(scaled.x, 125);
+        assert_eq!(scaled.y, 250);
+        assert_eq!(scaled.width, 375);
+        assert_eq!(scaled.height, 500);
     }
 
     // ==================== Validation Tests ====================
 
     #[test]
     fn test_validate_selection_minimum_size_pass() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
         let rect = Rect::new(0, 0, 10, 10);
-        let result = ScreenCapture::validate_selection(rect);
+        let result = capture.validate_selection(rect);
         assert!(result.is_ok(), "10x10 selection should be valid");
     }
 
     #[test]
     fn test_validate_selection_9x9_rejected() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
         let rect = Rect::new(0, 0, 9, 9);
-        let result = ScreenCapture::validate_selection(rect);
+        let result = capture.validate_selection(rect);
         assert!(
             matches!(result, Err(CaptureError::SelectionTooSmall)),
             "9x9 selection should be rejected"
@@ -617,8 +738,11 @@ mod tests {
 
     #[test]
     fn test_validate_selection_10x9_rejected() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
         let rect = Rect::new(0, 0, 10, 9);
-        let result = ScreenCapture::validate_selection(rect);
+        let result = capture.validate_selection(rect);
         assert!(
             matches!(result, Err(CaptureError::SelectionTooSmall)),
             "10x9 selection should be rejected"
@@ -627,19 +751,24 @@ mod tests {
 
     #[test]
     fn test_validate_selection_9x10_rejected() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
         let rect = Rect::new(0, 0, 9, 10);
-        let result = ScreenCapture::validate_selection(rect);
+        let result = capture.validate_selection(rect);
         assert!(
             matches!(result, Err(CaptureError::SelectionTooSmall)),
             "9x10 selection should be rejected"
         );
     }
 
+    // ==================== Clamping Tests ====================
+
     #[test]
     fn test_clamp_rect_extends_past_right_edge() {
         let rect = Rect::new(900, 0, 200, 100);
         let bounds = Rect::new(0, 0, 1000, 1000);
-        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+        let clamped = ScreenCapture::<MockScreenBackend>::clamp_rect_to_bounds(rect, bounds);
 
         assert_eq!(clamped.x, 900);
         assert_eq!(clamped.width, 100, "Should clamp width to screen boundary");
@@ -649,7 +778,7 @@ mod tests {
     fn test_clamp_rect_extends_past_bottom_edge() {
         let rect = Rect::new(0, 900, 100, 200);
         let bounds = Rect::new(0, 0, 1000, 1000);
-        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+        let clamped = ScreenCapture::<MockScreenBackend>::clamp_rect_to_bounds(rect, bounds);
 
         assert_eq!(clamped.y, 900);
         assert_eq!(clamped.height, 100, "Should clamp height to screen boundary");
@@ -659,7 +788,7 @@ mod tests {
     fn test_clamp_rect_negative_x_clamped() {
         let rect = Rect::new(-50, 0, 100, 100);
         let bounds = Rect::new(0, 0, 1000, 1000);
-        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+        let clamped = ScreenCapture::<MockScreenBackend>::clamp_rect_to_bounds(rect, bounds);
 
         assert_eq!(clamped.x, 0, "Negative x should be clamped to 0");
     }
@@ -668,18 +797,126 @@ mod tests {
     fn test_clamp_rect_negative_y_clamped() {
         let rect = Rect::new(0, -50, 100, 100);
         let bounds = Rect::new(0, 0, 1000, 1000);
-        let clamped = ScreenCapture::clamp_rect_to_bounds(rect, bounds);
+        let clamped = ScreenCapture::<MockScreenBackend>::clamp_rect_to_bounds(rect, bounds);
 
         assert_eq!(clamped.y, 0, "Negative y should be clamped to 0");
     }
 
-    // ==================== Screen Capture Tests ====================
+    // ==================== Monitor Detection Tests (using mock) ====================
 
     #[test]
-    #[cfg(target_os = "windows")]
+    fn test_get_monitors_returns_at_least_one() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
+        let monitors = capture.get_monitors().expect("Should detect monitors");
+        assert!(!monitors.is_empty(), "Should have at least one monitor");
+    }
+
+    #[test]
+    fn test_monitor_info_contains_valid_dimensions() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
+        let monitors = capture.get_monitors().expect("Should detect monitors");
+
+        for monitor in monitors {
+            assert!(monitor.width > 0, "Monitor width should be positive");
+            assert!(monitor.height > 0, "Monitor height should be positive");
+            assert!(monitor.width <= 8192, "Monitor width should be reasonable (<=8K)");
+            assert!(monitor.height <= 8192, "Monitor height should be reasonable (<=8K)");
+        }
+    }
+
+    #[test]
+    fn test_primary_monitor_detected() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
+        let monitors = capture.get_monitors().expect("Should detect monitors");
+        let primary_count = monitors.iter().filter(|m| m.is_primary).count();
+        assert_eq!(primary_count, 1, "Should have exactly one primary monitor");
+    }
+
+    #[test]
+    fn test_no_monitors_returns_error() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_monitors(vec![]);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let result = capture.get_monitors();
+        assert!(matches!(result, Err(CaptureError::NoMonitors)));
+    }
+
+    #[test]
+    fn test_multi_monitor_setup() {
+        let monitors = vec![
+            MonitorInfo {
+                id: 0,
+                name: "Monitor 1".to_string(),
+                x: 0,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                dpi_scale: 1.0,
+                is_primary: true,
+            },
+            MonitorInfo {
+                id: 1,
+                name: "Monitor 2".to_string(),
+                x: 1920,
+                y: 0,
+                width: 1920,
+                height: 1080,
+                dpi_scale: 1.5,
+                is_primary: false,
+            },
+        ];
+
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new()
+            .with_monitors(monitors)
+            .with_virtual_bounds(Rect::new(0, 0, 3840, 1080));
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let detected = capture.get_monitors().unwrap();
+        assert_eq!(detected.len(), 2);
+
+        let bounds = capture.get_virtual_screen_bounds();
+        assert_eq!(bounds.width, 3840);
+    }
+
+    // ==================== DPI Scale Tests (using mock) ====================
+
+    #[test]
+    fn test_dpi_scale_factor_valid_range() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_dpi_scale(1.5);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let scale = capture.backend.get_dpi_scale_at_point(0, 0);
+        assert!(scale >= 1.0, "DPI scale should be at least 1.0");
+        assert!(scale <= 4.0, "DPI scale should be at most 4.0 (400%)");
+    }
+
+    // ==================== Virtual Screen Bounds Tests ====================
+
+    #[test]
+    fn test_virtual_screen_bounds_valid() {
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
+
+        let bounds = capture.get_virtual_screen_bounds();
+        assert!(bounds.width > 0, "Virtual screen width should be positive");
+        assert!(bounds.height > 0, "Virtual screen height should be positive");
+    }
+
+    // ==================== Screen Capture Tests (using mock) ====================
+
+    #[test]
     fn test_capture_region_creates_valid_png() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
 
         let rect = Rect::new(0, 0, 100, 100);
         let result = capture.capture_region(rect);
@@ -696,29 +933,24 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "windows")]
     fn test_capture_region_correct_dimensions() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
 
         let rect = Rect::new(0, 0, 200, 150);
         let result = capture.capture_region(rect).expect("Capture should succeed");
 
         // Load the image and verify dimensions
         let img = image::open(&result.file_path).expect("Should load captured image");
-
-        // Note: actual dimensions may differ due to DPI scaling
-        // We just verify the image is loadable and has reasonable dimensions
-        assert!(img.width() > 0);
-        assert!(img.height() > 0);
+        assert_eq!(img.width(), 200);
+        assert_eq!(img.height(), 150);
     }
 
     #[test]
-    #[cfg(target_os = "windows")]
     fn test_capture_saves_to_temp_directory() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let temp_dir = TempDir::new().unwrap();
         let temp_path = temp_dir.path().to_path_buf();
-        let capture = ScreenCapture::new(temp_path.clone());
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_path.clone());
 
         let rect = Rect::new(0, 0, 50, 50);
         let result = capture.capture_region(rect).expect("Capture should succeed");
@@ -730,10 +962,9 @@ mod tests {
     }
 
     #[test]
-    #[cfg(target_os = "windows")]
     fn test_capture_unique_filename_generation() {
-        let temp_dir = TempDir::new().expect("Failed to create temp dir");
-        let capture = ScreenCapture::new(temp_dir.path().to_path_buf());
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.path().to_path_buf());
 
         let rect = Rect::new(0, 0, 20, 20);
 
@@ -746,14 +977,41 @@ mod tests {
         );
     }
 
-    // ==================== Permission Tests ====================
+    #[test]
+    fn test_capture_with_dpi_scaling() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_dpi_scale(2.0);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let rect = Rect::new(0, 0, 100, 100);
+        let result = capture.capture_region(rect).expect("Capture should succeed");
+
+        // With 2x DPI scaling, the physical dimensions should be doubled
+        assert_eq!(result.width, 200);
+        assert_eq!(result.height, 200);
+    }
+
+    // ==================== Permission Tests (using mock) ====================
 
     #[test]
-    #[cfg(target_os = "windows")]
-    fn test_permission_check_returns_result() {
-        let result = ScreenCapture::check_permission();
-        // Should return Ok(true) or an error, but not panic
-        assert!(result.is_ok() || result.is_err());
+    fn test_permission_check_granted() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_permission(true);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let result = capture.check_permission();
+        assert!(result.is_ok());
+        assert!(result.unwrap());
+    }
+
+    #[test]
+    fn test_permission_check_denied() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_permission(false);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        let result = capture.check_permission();
+        assert!(matches!(result, Err(CaptureError::PermissionDenied)));
     }
 
     // ==================== Error Type Tests ====================
@@ -762,17 +1020,46 @@ mod tests {
     fn test_capture_error_display() {
         let error = CaptureError::SelectionTooSmall;
         let msg = format!("{}", error);
-        assert!(
-            msg.contains("10x10"),
-            "Error message should mention minimum size"
-        );
+        assert!(msg.contains("10x10"), "Error message should mention minimum size");
     }
 
     #[test]
-    fn test_rect_is_valid_size() {
-        assert!(Rect::new(0, 0, 10, 10).is_valid_size(10, 10));
-        assert!(Rect::new(0, 0, 100, 100).is_valid_size(10, 10));
-        assert!(!Rect::new(0, 0, 9, 10).is_valid_size(10, 10));
-        assert!(!Rect::new(0, 0, 10, 9).is_valid_size(10, 10));
+    fn test_capture_error_types() {
+        // Ensure all error variants can be created and displayed
+        let errors = vec![
+            CaptureError::SelectionTooSmall,
+            CaptureError::OutOfBounds,
+            CaptureError::CaptureFailure("test".to_string()),
+            CaptureError::SaveFailure("test".to_string()),
+            CaptureError::NoMonitors,
+            CaptureError::PermissionDenied,
+            CaptureError::PlatformNotSupported,
+        ];
+
+        for error in errors {
+            let msg = format!("{}", error);
+            assert!(!msg.is_empty(), "Error should have display message");
+        }
+    }
+
+    // ==================== Mock Backend Tests ====================
+
+    #[test]
+    fn test_mock_backend_create_test_image() {
+        let img = MockScreenBackend::create_test_image(100, 50);
+        assert_eq!(img.width(), 100);
+        assert_eq!(img.height(), 50);
+    }
+
+    #[test]
+    fn test_mock_backend_builder_pattern() {
+        let backend = MockScreenBackend::new()
+            .with_dpi_scale(1.5)
+            .with_virtual_bounds(Rect::new(0, 0, 3840, 2160))
+            .with_permission(false);
+
+        assert_eq!(backend.dpi_scale, 1.5);
+        assert_eq!(backend.virtual_bounds.width, 3840);
+        assert!(!backend.permission_granted);
     }
 }

--- a/wrapper/src-tauri/src/capture.rs
+++ b/wrapper/src-tauri/src/capture.rs
@@ -250,11 +250,22 @@ mod windows_backend {
 
                 let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
 
-                dpi_x as f64 / 96.0
+                // Use average of X and Y DPI in case they differ (rare but possible)
+                ((dpi_x as f64 + dpi_y as f64) / 2.0) / 96.0
             }
         }
 
         fn capture_region_pixels(&self, rect: Rect) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
+            // Validate that rect is within screen bounds before attempting capture
+            let bounds = self.get_virtual_screen_bounds();
+            if rect.x < bounds.x
+                || rect.y < bounds.y
+                || rect.x + rect.width as i32 > bounds.x + bounds.width as i32
+                || rect.y + rect.height as i32 > bounds.y + bounds.height as i32
+            {
+                return Err(CaptureError::OutOfBounds);
+            }
+
             // SAFETY: This function uses Windows GDI APIs to capture screen content.
             // All GDI resources are properly managed with cleanup on all code paths:
             // - screen_dc: Released via ReleaseDC on all error paths and success path
@@ -339,7 +350,13 @@ mod windows_backend {
                 };
 
                 // Allocate buffer for pixel data
-                let buffer_size = (rect.width * rect.height * 4) as usize;
+                // Use checked arithmetic to prevent integer overflow on very large captures
+                let buffer_size = (rect.width as usize)
+                    .checked_mul(rect.height as usize)
+                    .and_then(|size| size.checked_mul(4))
+                    .ok_or_else(|| CaptureError::CaptureFailure(
+                        "Image dimensions too large for buffer allocation".to_string()
+                    ))?;
                 let mut buffer: Vec<u8> = vec![0; buffer_size];
 
                 // Get the bitmap bits
@@ -429,7 +446,8 @@ mod windows_backend {
             let mut dpi_x: u32 = 96;
             let mut dpi_y: u32 = 96;
             let _ = GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi_x, &mut dpi_y);
-            let dpi_scale = dpi_x as f64 / 96.0;
+            // Use average of X and Y DPI in case they differ (rare but possible)
+            let dpi_scale = ((dpi_x as f64 + dpi_y as f64) / 2.0) / 96.0;
 
             // Get monitor name
             let name_slice = &monitor_info.szDevice;
@@ -609,13 +627,28 @@ impl<B: ScreenBackend> ScreenCapture<B> {
     }
 
     /// Apply DPI scaling to convert logical coordinates to physical pixels
-    pub fn apply_dpi_scaling(rect: Rect, scale: f64) -> Rect {
-        Rect::new(
+    ///
+    /// # Arguments
+    /// * `rect` - The rectangle in logical coordinates
+    /// * `scale` - DPI scale factor (typically 1.0 to 4.0)
+    ///
+    /// # Returns
+    /// Scaled rectangle, or error if scale is invalid
+    pub fn apply_dpi_scaling(rect: Rect, scale: f64) -> Result<Rect, CaptureError> {
+        // Validate scale is within reasonable bounds
+        // DPI scaling typically ranges from 100% (1.0) to 400% (4.0)
+        if scale <= 0.0 || scale > 10.0 {
+            return Err(CaptureError::CaptureFailure(
+                format!("Invalid DPI scale factor: {}. Expected 0.0 < scale <= 10.0", scale)
+            ));
+        }
+
+        Ok(Rect::new(
             (rect.x as f64 * scale) as i32,
             (rect.y as f64 * scale) as i32,
             (rect.width as f64 * scale) as u32,
             (rect.height as f64 * scale) as u32,
-        )
+        ))
     }
 
     /// Clean up old capture files from the temp directory
@@ -682,7 +715,7 @@ impl<B: ScreenBackend> ScreenCapture<B> {
         debug!("DPI scale factor: {}", dpi_scale);
 
         // Apply DPI scaling to get physical pixel coordinates
-        let physical_rect = Self::apply_dpi_scaling(validated_rect, dpi_scale);
+        let physical_rect = Self::apply_dpi_scaling(validated_rect, dpi_scale)?;
 
         // Capture the screen region
         let image_data = self.backend.capture_region_pixels(physical_rect)?;
@@ -805,7 +838,7 @@ mod tests {
     #[test]
     fn test_apply_dpi_scaling_100_percent() {
         let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.0);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.0).unwrap();
 
         assert_eq!(scaled.x, 100);
         assert_eq!(scaled.y, 200);
@@ -816,7 +849,7 @@ mod tests {
     #[test]
     fn test_apply_dpi_scaling_150_percent() {
         let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.5);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.5).unwrap();
 
         assert_eq!(scaled.x, 150);
         assert_eq!(scaled.y, 300);
@@ -827,7 +860,7 @@ mod tests {
     #[test]
     fn test_apply_dpi_scaling_200_percent() {
         let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 2.0);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 2.0).unwrap();
 
         assert_eq!(scaled.x, 200);
         assert_eq!(scaled.y, 400);
@@ -838,12 +871,33 @@ mod tests {
     #[test]
     fn test_apply_dpi_scaling_125_percent() {
         let rect = Rect::new(100, 200, 300, 400);
-        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.25);
+        let scaled = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 1.25).unwrap();
 
         assert_eq!(scaled.x, 125);
         assert_eq!(scaled.y, 250);
         assert_eq!(scaled.width, 375);
         assert_eq!(scaled.height, 500);
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_invalid_zero() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let result = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 0.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_invalid_negative() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let result = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, -1.0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_apply_dpi_scaling_invalid_too_large() {
+        let rect = Rect::new(100, 200, 300, 400);
+        let result = ScreenCapture::<MockScreenBackend>::apply_dpi_scaling(rect, 11.0);
+        assert!(result.is_err());
     }
 
     // ==================== Validation Tests ====================

--- a/wrapper/src-tauri/src/capture.rs
+++ b/wrapper/src-tauri/src/capture.rs
@@ -1,5 +1,49 @@
-//! Screen capture module with platform abstraction for testability
-//! Handles monitor detection, DPI scaling, and screen region capture
+//! Screen capture module with platform abstraction for testability.
+//! Handles monitor detection, DPI scaling, and screen region capture.
+//!
+//! # Platform Support
+//!
+//! **IMPORTANT**: Actual screen capture functionality is only available on Windows.
+//!
+//! | Platform | Status | Implementation |
+//! |----------|--------|----------------|
+//! | Windows  | ✅ Full support | Windows GDI API (GetDC, BitBlt, GetDIBits) |
+//! | macOS    | ❌ Mock only | MockScreenBackend for testing |
+//! | Linux    | ❌ Mock only | MockScreenBackend for testing |
+//!
+//! On non-Windows platforms, the module compiles and can be tested using `MockScreenBackend`,
+//! but actual screen capture will not work. The mock backend generates a solid color test image
+//! instead of capturing the screen.
+//!
+//! # Architecture
+//!
+//! The module uses a trait-based abstraction (`ScreenBackend`) to separate capture logic from
+//! platform-specific implementation, allowing for easy testing and potential future platform support.
+//!
+//! # Usage
+//!
+//! ```rust
+//! use porua_wrapper::capture::{ScreenCapture, MockScreenBackend, Rect};
+//! use std::path::PathBuf;
+//!
+//! // Create a capture instance with mock backend (works on all platforms)
+//! let temp_dir = std::env::temp_dir().join("capture_test");
+//! let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir);
+//!
+//! // Check monitors
+//! let monitors = capture.get_monitors().unwrap();
+//! assert!(!monitors.is_empty());
+//!
+//! // Capture a region
+//! let rect = Rect::new(0, 0, 100, 100);
+//! let result = capture.capture_region(rect).unwrap();
+//! assert!(!result.file_path.is_empty());
+//! ```
+//!
+//! # Future Work
+//!
+//! - macOS: Could implement using Core Graphics (CGWindowListCreateImage)
+//! - Linux: Could implement using X11 (XGetImage) or Wayland protocols
 
 use anyhow::Result;
 use image::{ImageBuffer, Rgba};
@@ -137,6 +181,12 @@ mod windows_backend {
             let mut monitors: Vec<MonitorInfo> = Vec::new();
             let monitors_ptr = &mut monitors as *mut Vec<MonitorInfo>;
 
+            // SAFETY: EnumDisplayMonitors is a Windows API that iterates over all display monitors.
+            // - We pass a valid callback function (enum_monitor_callback) that matches the expected signature.
+            // - The LPARAM contains a pointer to our Vec which remains valid for the duration of the call
+            //   since we don't return until EnumDisplayMonitors completes synchronously.
+            // - The callback properly casts the LPARAM back to &mut Vec<MonitorInfo> and appends to it.
+            // - HDC::default() (null) is valid for EnumDisplayMonitors, meaning enumerate all monitors.
             unsafe {
                 let result = EnumDisplayMonitors(
                     HDC::default(),
@@ -166,6 +216,10 @@ mod windows_backend {
         }
 
         fn get_virtual_screen_bounds(&self) -> Rect {
+            // SAFETY: GetSystemMetrics is a safe Windows API that retrieves system metrics.
+            // - These specific metrics (SM_XVIRTUALSCREEN, etc.) return screen dimensions.
+            // - The function has no side effects and cannot cause undefined behavior.
+            // - Return values are plain integers that are always valid.
             unsafe {
                 let x = GetSystemMetrics(SM_XVIRTUALSCREEN);
                 let y = GetSystemMetrics(SM_YVIRTUALSCREEN);
@@ -182,6 +236,11 @@ mod windows_backend {
         }
 
         fn get_dpi_scale_at_point(&self, x: i32, y: i32) -> f64 {
+            // SAFETY: MonitorFromPoint and GetDpiForMonitor are safe Windows APIs.
+            // - MonitorFromPoint returns a valid HMONITOR handle for any point (uses MONITOR_DEFAULTTONEAREST).
+            // - GetDpiForMonitor writes to our stack-allocated u32 variables which are properly aligned.
+            // - Even if GetDpiForMonitor fails, we have initialized dpi_x/dpi_y to 96 (default DPI).
+            // - No resources need cleanup; HMONITOR handles don't require explicit release.
             unsafe {
                 let point = POINT { x, y };
                 let monitor = MonitorFromPoint(point, MONITOR_DEFAULTTONEAREST);
@@ -196,6 +255,19 @@ mod windows_backend {
         }
 
         fn capture_region_pixels(&self, rect: Rect) -> Result<ImageBuffer<Rgba<u8>, Vec<u8>>, CaptureError> {
+            // SAFETY: This function uses Windows GDI APIs to capture screen content.
+            // All GDI resources are properly managed with cleanup on all code paths:
+            // - screen_dc: Released via ReleaseDC on all error paths and success path
+            // - capture_dc: Deleted via DeleteDC on all error paths and success path
+            // - bitmap: Deleted via DeleteObject on all error paths and success path
+            // - old_bitmap: Restored via SelectObject before bitmap deletion
+            //
+            // The buffer passed to GetDIBits is:
+            // - Properly sized: width * height * 4 bytes (32-bit BGRA)
+            // - Properly aligned: Vec<u8> guarantees alignment for u8
+            // - Valid for the duration of the call
+            //
+            // HWND::default() (null) is valid for GetDC, meaning the entire screen.
             unsafe {
                 // Get screen device context
                 let screen_dc = GetDC(HWND::default());
@@ -281,7 +353,7 @@ mod windows_backend {
                     DIB_RGB_COLORS,
                 );
 
-                // Cleanup GDI resources
+                // Cleanup GDI resources in reverse order of acquisition
                 SelectObject(capture_dc, old_bitmap);
                 DeleteObject(bitmap);
                 DeleteDC(capture_dc);
@@ -307,6 +379,11 @@ mod windows_backend {
         }
 
         fn check_permission(&self) -> Result<bool, CaptureError> {
+            // SAFETY: GetDC and ReleaseDC are safe Windows APIs.
+            // - GetDC(null) returns a DC for the entire screen, which we use to test access.
+            // - We immediately release the DC after checking if it's valid.
+            // - If GetDC fails (returns invalid), we don't call ReleaseDC.
+            // - No other resources are allocated.
             unsafe {
                 let screen_dc = GetDC(HWND::default());
                 if screen_dc.is_invalid() {
@@ -319,12 +396,21 @@ mod windows_backend {
     }
 
     /// Callback function for EnumDisplayMonitors
+    ///
+    /// # Safety
+    /// This function is called by Windows during EnumDisplayMonitors enumeration.
+    /// - `monitor` is a valid HMONITOR handle provided by Windows
+    /// - `lparam` must contain a valid pointer to a `Vec<MonitorInfo>` that outlives the enumeration
+    /// - The caller (get_monitors) ensures lparam points to a valid, properly aligned Vec
+    /// - This callback is synchronous and completes before get_monitors returns
     unsafe extern "system" fn enum_monitor_callback(
         monitor: windows::Win32::Graphics::Gdi::HMONITOR,
         _hdc: HDC,
         _rect: *mut RECT,
         lparam: LPARAM,
     ) -> BOOL {
+        // SAFETY: lparam was set by get_monitors to point to a valid Vec<MonitorInfo>
+        // that remains valid for the duration of the EnumDisplayMonitors call.
         let monitors = &mut *(lparam.0 as *mut Vec<MonitorInfo>);
 
         let mut monitor_info = MONITORINFOEXW {
@@ -530,6 +616,55 @@ impl<B: ScreenBackend> ScreenCapture<B> {
             (rect.width as f64 * scale) as u32,
             (rect.height as f64 * scale) as u32,
         )
+    }
+
+    /// Clean up old capture files from the temp directory
+    /// Removes files older than `max_age_hours` hours
+    /// Returns the number of files deleted
+    pub fn cleanup_old_captures(&self, max_age_hours: u64) -> Result<usize, CaptureError> {
+        use std::time::{Duration, SystemTime};
+
+        if !self.temp_dir.exists() {
+            return Ok(0);
+        }
+
+        let max_age = Duration::from_secs(max_age_hours * 60 * 60);
+        let cutoff_time = SystemTime::now()
+            .checked_sub(max_age)
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+
+        let mut deleted_count = 0;
+
+        let entries = std::fs::read_dir(&self.temp_dir).map_err(|e| {
+            CaptureError::SaveFailure(format!("Failed to read capture directory: {}", e))
+        })?;
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+
+            // Only delete .png files that match our capture filename pattern
+            if let Some(filename) = path.file_name().and_then(|n| n.to_str()) {
+                if filename.starts_with("capture_") && filename.ends_with(".png") {
+                    // Check file modification time
+                    if let Ok(metadata) = std::fs::metadata(&path) {
+                        if let Ok(modified) = metadata.modified() {
+                            if modified < cutoff_time {
+                                if std::fs::remove_file(&path).is_ok() {
+                                    debug!("Deleted old capture: {:?}", path);
+                                    deleted_count += 1;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if deleted_count > 0 {
+            info!("Cleaned up {} old capture files", deleted_count);
+        }
+
+        Ok(deleted_count)
     }
 
     /// Capture a region of the screen and save to file
@@ -1061,5 +1196,194 @@ mod tests {
         assert_eq!(backend.dpi_scale, 1.5);
         assert_eq!(backend.virtual_bounds.width, 3840);
         assert!(!backend.permission_granted);
+    }
+
+    // ==================== Integration Tests ====================
+    // These tests verify the complete capture workflow end-to-end
+
+    #[test]
+    fn test_integration_complete_capture_workflow() {
+        // This test simulates the complete capture workflow from selection to save
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new()
+            .with_monitors(vec![
+                MonitorInfo {
+                    id: 0,
+                    name: "Primary".to_string(),
+                    x: 0,
+                    y: 0,
+                    width: 1920,
+                    height: 1080,
+                    dpi_scale: 1.0,
+                    is_primary: true,
+                },
+            ])
+            .with_virtual_bounds(Rect::new(0, 0, 1920, 1080))
+            .with_permission(true);
+
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        // 1. Check permission first (as the overlay would)
+        let has_permission = capture.check_permission();
+        assert!(has_permission.is_ok());
+        assert!(has_permission.unwrap());
+
+        // 2. Get monitor info (as the overlay would for positioning)
+        let monitors = capture.get_monitors();
+        assert!(monitors.is_ok());
+        assert_eq!(monitors.unwrap().len(), 1);
+
+        // 3. Simulate user making a selection (300x200 region)
+        let user_selection = Rect::from_points(100, 100, 400, 300);
+        assert_eq!(user_selection.width, 300);
+        assert_eq!(user_selection.height, 200);
+
+        // 4. Validate the selection
+        let validated = capture.validate_selection(user_selection);
+        assert!(validated.is_ok());
+
+        // 5. Capture the region
+        let result = capture.capture_region(user_selection);
+        assert!(result.is_ok());
+
+        let capture_result = result.unwrap();
+
+        // 6. Verify the result
+        assert!(!capture_result.file_path.is_empty());
+        assert!(!capture_result.timestamp.is_empty());
+        assert_eq!(capture_result.width, 300);
+        assert_eq!(capture_result.height, 200);
+
+        // 7. Verify the file exists and is valid
+        let path = std::path::Path::new(&capture_result.file_path);
+        assert!(path.exists(), "Captured file should exist at: {}", capture_result.file_path);
+        assert!(path.extension().map_or(false, |ext| ext == "png"));
+
+        // 8. Verify the image can be loaded
+        let loaded = image::open(path);
+        assert!(loaded.is_ok(), "Image should be loadable");
+
+        let img = loaded.unwrap();
+        assert_eq!(img.width(), 300);
+        assert_eq!(img.height(), 200);
+    }
+
+    #[test]
+    fn test_integration_capture_with_dpi_scaling() {
+        // Test that captures work correctly with high DPI displays
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new()
+            .with_dpi_scale(2.0) // Retina display
+            .with_permission(true);
+
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        // Capture a 100x100 logical region
+        let selection = Rect::new(0, 0, 100, 100);
+        let result = capture.capture_region(selection).unwrap();
+
+        // With 2x DPI, physical pixels should be 200x200
+        assert_eq!(result.width, 200);
+        assert_eq!(result.height, 200);
+
+        // Verify the actual image dimensions
+        let img = image::open(&result.file_path).unwrap();
+        assert_eq!(img.width(), 200);
+        assert_eq!(img.height(), 200);
+    }
+
+    #[test]
+    fn test_integration_capture_cleanup_workflow() {
+        use std::fs::File;
+        use std::io::Write;
+
+        let temp_dir = TempDir::new().unwrap();
+        let capture_dir = temp_dir.path().join("captures");
+        std::fs::create_dir_all(&capture_dir).unwrap();
+
+        // Create some old capture files (simulated)
+        let old_file = capture_dir.join("capture_20230101_120000_abc123.png");
+        let mut f = File::create(&old_file).unwrap();
+        f.write_all(b"fake png data").unwrap();
+
+        // Create a new capture file
+        let new_file = capture_dir.join("capture_20991231_235959_xyz789.png");
+        let mut f = File::create(&new_file).unwrap();
+        f.write_all(b"fake png data").unwrap();
+
+        let capture = ScreenCapture::with_backend(
+            MockScreenBackend::new(),
+            capture_dir.clone(),
+        );
+
+        // Cleanup files older than 0 hours (all files)
+        let deleted = capture.cleanup_old_captures(0).unwrap();
+        assert_eq!(deleted, 2, "Both files should be deleted with 0 hour max age");
+
+        // Verify files are deleted
+        assert!(!old_file.exists());
+        assert!(!new_file.exists());
+    }
+
+    #[test]
+    fn test_integration_multi_capture_session() {
+        // Test multiple captures in sequence (as a user would do)
+        let temp_dir = TempDir::new().unwrap();
+        let capture = ScreenCapture::with_backend(
+            MockScreenBackend::new(),
+            temp_dir.path().to_path_buf(),
+        );
+
+        let mut file_paths = Vec::new();
+
+        // Capture 5 different regions
+        for i in 0..5 {
+            let rect = Rect::new(i * 10, i * 10, 50 + i as u32 * 10, 50 + i as u32 * 10);
+            let result = capture.capture_region(rect).expect("Each capture should succeed");
+            file_paths.push(result.file_path);
+        }
+
+        // Verify all files are unique
+        let unique_paths: std::collections::HashSet<_> = file_paths.iter().collect();
+        assert_eq!(unique_paths.len(), 5, "All capture files should have unique paths");
+
+        // Verify all files exist
+        for path in &file_paths {
+            assert!(std::path::Path::new(path).exists(), "File should exist: {}", path);
+        }
+    }
+
+    #[test]
+    fn test_integration_permission_denied_blocks_capture() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new().with_permission(false);
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        // First check should return permission denied
+        let permission = capture.check_permission();
+        assert!(matches!(permission, Err(CaptureError::PermissionDenied)));
+
+        // Note: In the real app, UI would block capture attempt after permission check
+        // The capture_region itself doesn't check permission - that's the UI's job
+    }
+
+    #[test]
+    fn test_integration_edge_selection_at_screen_boundary() {
+        let temp_dir = TempDir::new().unwrap();
+        let backend = MockScreenBackend::new()
+            .with_virtual_bounds(Rect::new(0, 0, 1920, 1080));
+        let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+
+        // Selection that extends past the screen edge
+        let selection = Rect::new(1800, 900, 200, 200); // Extends 80px past right, 20px past bottom
+
+        // Should clamp to screen bounds
+        let validated = capture.validate_selection(selection).unwrap();
+        assert!(validated.x + validated.width as i32 <= 1920);
+        assert!(validated.y + validated.height as i32 <= 1080);
+
+        // Capture should still succeed
+        let result = capture.capture_region(selection);
+        assert!(result.is_ok());
     }
 }

--- a/wrapper/src-tauri/src/lib.rs
+++ b/wrapper/src-tauri/src/lib.rs
@@ -1,0 +1,10 @@
+//! Porua Wrapper Library
+//!
+//! This module exposes the internal modules for integration testing.
+//! The main application entry point is in main.rs.
+
+pub mod capture;
+pub mod config;
+pub mod installer;
+pub mod paths;
+pub mod server;

--- a/wrapper/src-tauri/src/main.rs
+++ b/wrapper/src-tauri/src/main.rs
@@ -3,6 +3,7 @@
     windows_subsystem = "windows"
 )]
 
+mod capture;
 mod config;
 mod installer;
 mod paths;
@@ -16,6 +17,7 @@ use tokio::sync::Mutex;
 use tracing::{error, info};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
+use crate::capture::{CaptureResult, MonitorInfo, Rect, ScreenCapture};
 use crate::config::Config;
 use crate::installer::Installer;
 use crate::server::{ServerManager, ServerStatus};
@@ -130,6 +132,189 @@ async fn quit_app(app_handle: tauri::AppHandle, state: tauri::State<'_, AppState
     Ok(())
 }
 
+// ==================== Screen Capture Commands ====================
+
+#[tauri::command]
+async fn get_monitors_info() -> Result<Vec<MonitorInfo>, String> {
+    info!("get_monitors_info command called");
+    ScreenCapture::get_monitors().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+async fn start_capture_mode(app_handle: tauri::AppHandle) -> Result<(), String> {
+    info!("start_capture_mode command called");
+
+    // Hide main window if it exists
+    if let Some(window) = app_handle.get_window("main") {
+        let _ = window.hide();
+    }
+
+    // Check if overlay already exists
+    if app_handle.get_window("capture-overlay").is_some() {
+        info!("Capture overlay already exists");
+        return Ok(());
+    }
+
+    // Create the overlay window
+    let overlay = tauri::WindowBuilder::new(
+        &app_handle,
+        "capture-overlay",
+        tauri::WindowUrl::App("overlay.html".into()),
+    )
+    .title("Screen Capture")
+    .fullscreen(true)
+    .transparent(true)
+    .decorations(false)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .build()
+    .map_err(|e| format!("Failed to create overlay window: {}", e))?;
+
+    overlay.show().map_err(|e| e.to_string())?;
+    overlay.set_focus().map_err(|e| e.to_string())?;
+
+    info!("Capture overlay window created");
+    Ok(())
+}
+
+#[tauri::command]
+async fn cancel_capture(app_handle: tauri::AppHandle) -> Result<(), String> {
+    info!("cancel_capture command called");
+
+    // Close overlay window
+    if let Some(overlay) = app_handle.get_window("capture-overlay") {
+        overlay.close().map_err(|e| e.to_string())?;
+    }
+
+    // Show main window again if it exists
+    if let Some(main_window) = app_handle.get_window("main") {
+        let _ = main_window.show();
+        let _ = main_window.set_focus();
+    }
+
+    info!("Capture cancelled");
+    Ok(())
+}
+
+#[tauri::command]
+async fn capture_screen_region(
+    app_handle: tauri::AppHandle,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+) -> Result<CaptureResult, String> {
+    info!(
+        "capture_screen_region command called: x={}, y={}, width={}, height={}",
+        x, y, width, height
+    );
+
+    // Get temp directory for captures
+    let temp_dir = paths::get_app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("captures");
+
+    let capture = ScreenCapture::new(temp_dir);
+    let rect = Rect::new(x, y, width, height);
+
+    // Close overlay window before capturing
+    if let Some(overlay) = app_handle.get_window("capture-overlay") {
+        overlay.close().map_err(|e| e.to_string())?;
+    }
+
+    // Small delay to ensure overlay is fully closed
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Perform capture
+    let result = capture.capture_region(rect).map_err(|e| e.to_string())?;
+
+    info!("Screen region captured successfully: {:?}", result.file_path);
+    Ok(result)
+}
+
+#[tauri::command]
+async fn open_preview_window(
+    app_handle: tauri::AppHandle,
+    image_path: String,
+    timestamp: String,
+) -> Result<(), String> {
+    info!("open_preview_window command called: {}", image_path);
+
+    // Check if preview window already exists
+    if let Some(existing) = app_handle.get_window("capture-preview") {
+        existing.close().map_err(|e| e.to_string())?;
+    }
+
+    // Create preview window
+    let preview = tauri::WindowBuilder::new(
+        &app_handle,
+        "capture-preview",
+        tauri::WindowUrl::App("preview.html".into()),
+    )
+    .title(format!("Capture - {}", timestamp))
+    .inner_size(800.0, 600.0)
+    .min_inner_size(400.0, 300.0)
+    .resizable(true)
+    .center()
+    .build()
+    .map_err(|e| format!("Failed to create preview window: {}", e))?;
+
+    preview.show().map_err(|e| e.to_string())?;
+    preview.set_focus().map_err(|e| e.to_string())?;
+
+    // Emit the image path to the preview window
+    preview
+        .emit("load-image", &image_path)
+        .map_err(|e| e.to_string())?;
+
+    info!("Preview window opened");
+    Ok(())
+}
+
+#[tauri::command]
+async fn save_captured_image(
+    app_handle: tauri::AppHandle,
+    source_path: String,
+) -> Result<String, String> {
+    info!("save_captured_image command called: {}", source_path);
+
+    use tauri::api::dialog::blocking::FileDialogBuilder;
+
+    // Show save dialog
+    let save_path = FileDialogBuilder::new()
+        .add_filter("PNG Image", &["png"])
+        .set_file_name("capture.png")
+        .save_file();
+
+    match save_path {
+        Some(path) => {
+            // Copy file to selected location
+            std::fs::copy(&source_path, &path).map_err(|e| {
+                error!("Failed to save image: {}", e);
+                format!("Failed to save image: {}", e)
+            })?;
+
+            info!("Image saved to: {:?}", path);
+            Ok(path.to_string_lossy().to_string())
+        }
+        None => {
+            info!("Save dialog cancelled");
+            Err("Save cancelled".to_string())
+        }
+    }
+}
+
+#[tauri::command]
+async fn check_capture_permission() -> Result<bool, String> {
+    info!("check_capture_permission command called");
+    ScreenCapture::check_permission().map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+fn get_virtual_screen_bounds() -> Rect {
+    ScreenCapture::get_virtual_screen_bounds()
+}
+
 fn main() {
     // Initialize logging - use fallback if file logging fails
     let file_logging_result = (|| -> anyhow::Result<()> {
@@ -201,6 +386,15 @@ fn main() {
             close_installer_window,
             get_log_path,
             quit_app,
+            // Screen capture commands
+            get_monitors_info,
+            start_capture_mode,
+            cancel_capture,
+            capture_screen_region,
+            open_preview_window,
+            save_captured_image,
+            check_capture_permission,
+            get_virtual_screen_bounds,
         ])
         .setup(|app| {
             let app_handle = app.handle();

--- a/wrapper/src-tauri/src/main.rs
+++ b/wrapper/src-tauri/src/main.rs
@@ -11,7 +11,8 @@ mod server;
 
 use std::sync::Arc;
 use tauri::{
-    CustomMenuItem, Icon, Manager, SystemTray, SystemTrayEvent, SystemTrayMenu, SystemTrayMenuItem,
+    CustomMenuItem, GlobalShortcutManager, Icon, Manager, SystemTray, SystemTrayEvent,
+    SystemTrayMenu, SystemTrayMenuItem,
 };
 use tokio::sync::Mutex;
 use tracing::{error, info};
@@ -422,6 +423,9 @@ fn main() {
             // Note: No window is created initially (windows: [] in tauri.conf.json)
             // Windows are created programmatically only when needed (e.g., for installation)
 
+            // Register global keyboard shortcut for screen capture
+            register_capture_shortcut(&app_handle);
+
             // Spawn async setup
             tauri::async_runtime::spawn(async move {
                 if let Err(e) = setup_app(app_handle).await {
@@ -523,6 +527,19 @@ async fn setup_app(app_handle: tauri::AppHandle) -> anyhow::Result<()> {
 fn create_tray_menu(status: &ServerStatus) -> SystemTrayMenu {
     let mut menu = SystemTrayMenu::new();
 
+    // Add capture option at the top (available in all states)
+    #[cfg(target_os = "macos")]
+    let shortcut_hint = "⌘⇧S";
+    #[cfg(not(target_os = "macos"))]
+    let shortcut_hint = "Ctrl+Shift+S";
+
+    menu = menu
+        .add_item(CustomMenuItem::new(
+            "capture",
+            format!("Capture Screen    {}", shortcut_hint),
+        ))
+        .add_native_item(SystemTrayMenuItem::Separator);
+
     match status {
         ServerStatus::Stopped | ServerStatus::Error(_) => {
             // Show Start button when stopped or in error
@@ -623,10 +640,82 @@ fn update_tray_menu(app_handle: &tauri::AppHandle, status: &ServerStatus) {
     }
 }
 
+/// Helper function to trigger screen capture mode
+/// Used by both tray menu and global shortcut
+async fn trigger_capture(app_handle: &tauri::AppHandle) {
+    // Check if overlay already exists
+    if app_handle.get_window("capture-overlay").is_some() {
+        info!("Capture overlay already open, ignoring trigger");
+        return;
+    }
+
+    // Hide main window if it exists
+    if let Some(window) = app_handle.get_window("main") {
+        let _ = window.hide();
+    }
+
+    // Create the overlay window
+    match tauri::WindowBuilder::new(
+        app_handle,
+        "capture-overlay",
+        tauri::WindowUrl::App("overlay.html".into()),
+    )
+    .title("Screen Capture")
+    .fullscreen(true)
+    .transparent(true)
+    .decorations(false)
+    .always_on_top(true)
+    .skip_taskbar(true)
+    .build()
+    {
+        Ok(overlay) => {
+            if let Err(e) = overlay.show() {
+                error!("Failed to show overlay: {}", e);
+            }
+            if let Err(e) = overlay.set_focus() {
+                error!("Failed to focus overlay: {}", e);
+            }
+            info!("Capture overlay window created via shortcut/tray");
+        }
+        Err(e) => {
+            error!("Failed to create overlay window: {}", e);
+        }
+    }
+}
+
+/// Register global keyboard shortcut for screen capture
+fn register_capture_shortcut(app_handle: &tauri::AppHandle) {
+    let handle = app_handle.clone();
+
+    // Use Cmd+Shift+S on macOS, Ctrl+Shift+S on other platforms
+    #[cfg(target_os = "macos")]
+    let shortcut = "Cmd+Shift+S";
+    #[cfg(not(target_os = "macos"))]
+    let shortcut = "Ctrl+Shift+S";
+
+    match app_handle.global_shortcut_manager().register(shortcut, move || {
+        info!("Global shortcut {} triggered", shortcut);
+        let app = handle.clone();
+        tauri::async_runtime::spawn(async move {
+            trigger_capture(&app).await;
+        });
+    }) {
+        Ok(_) => info!("Registered global shortcut: {}", shortcut),
+        Err(e) => error!("Failed to register global shortcut {}: {}", shortcut, e),
+    }
+}
+
 fn handle_tray_event(app: &tauri::AppHandle, event_id: &str) {
     info!("Tray event: {}", event_id);
 
     match event_id {
+        "capture" => {
+            let app_handle = app.clone();
+            tauri::async_runtime::spawn(async move {
+                info!("Capture requested from tray menu");
+                trigger_capture(&app_handle).await;
+            });
+        }
         "start" => {
             let app_handle = app.clone();
             tauri::async_runtime::spawn(async move {

--- a/wrapper/src-tauri/src/main.rs
+++ b/wrapper/src-tauri/src/main.rs
@@ -325,6 +325,24 @@ fn get_virtual_screen_bounds() -> Rect {
     get_virtual_screen_bounds_native()
 }
 
+#[tauri::command]
+async fn cleanup_old_captures() -> Result<usize, String> {
+    info!("cleanup_old_captures command called");
+
+    let temp_dir = paths::get_app_data_dir()
+        .map_err(|e| e.to_string())?
+        .join("captures");
+
+    #[cfg(target_os = "windows")]
+    let capture = crate::capture::create_screen_capture(temp_dir);
+
+    #[cfg(not(target_os = "windows"))]
+    let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir);
+
+    // Clean up captures older than 24 hours
+    capture.cleanup_old_captures(24).map_err(|e| e.to_string())
+}
+
 fn main() {
     // Initialize logging - use fallback if file logging fails
     let file_logging_result = (|| -> anyhow::Result<()> {
@@ -405,6 +423,7 @@ fn main() {
             save_captured_image,
             check_capture_permission,
             get_virtual_screen_bounds,
+            cleanup_old_captures,
         ])
         .setup(|app| {
             let app_handle = app.handle();
@@ -489,6 +508,22 @@ async fn setup_app(app_handle: tauri::AppHandle) -> anyhow::Result<()> {
     }
 
     // Already installed - proceed normally
+
+    // Clean up old capture files on startup (captures older than 24 hours)
+    let temp_dir = paths::get_app_data_dir()?.join("captures");
+    if temp_dir.exists() {
+        #[cfg(target_os = "windows")]
+        let capture = crate::capture::create_screen_capture(temp_dir.clone());
+
+        #[cfg(not(target_os = "windows"))]
+        let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir.clone());
+
+        match capture.cleanup_old_captures(24) {
+            Ok(count) if count > 0 => info!("Cleaned up {} old capture files on startup", count),
+            Ok(_) => {}
+            Err(e) => error!("Failed to cleanup old captures on startup: {}", e),
+        }
+    }
 
     // Load configuration
     let config = Config::load()?;

--- a/wrapper/src-tauri/src/main.rs
+++ b/wrapper/src-tauri/src/main.rs
@@ -17,7 +17,10 @@ use tokio::sync::Mutex;
 use tracing::{error, info};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
-use crate::capture::{CaptureResult, MonitorInfo, Rect, ScreenCapture};
+use crate::capture::{
+    CaptureResult, MockScreenBackend, MonitorInfo, Rect, ScreenCapture,
+    get_monitors_native, get_virtual_screen_bounds_native, check_permission_native,
+};
 use crate::config::Config;
 use crate::installer::Installer;
 use crate::server::{ServerManager, ServerStatus};
@@ -137,7 +140,7 @@ async fn quit_app(app_handle: tauri::AppHandle, state: tauri::State<'_, AppState
 #[tauri::command]
 async fn get_monitors_info() -> Result<Vec<MonitorInfo>, String> {
     info!("get_monitors_info command called");
-    ScreenCapture::get_monitors().map_err(|e| e.to_string())
+    get_monitors_native().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -214,7 +217,13 @@ async fn capture_screen_region(
         .map_err(|e| e.to_string())?
         .join("captures");
 
-    let capture = ScreenCapture::new(temp_dir);
+    // Use mock backend on non-Windows platforms, real backend on Windows
+    #[cfg(target_os = "windows")]
+    let capture = crate::capture::create_screen_capture(temp_dir);
+
+    #[cfg(not(target_os = "windows"))]
+    let capture = ScreenCapture::with_backend(MockScreenBackend::new(), temp_dir);
+
     let rect = Rect::new(x, y, width, height);
 
     // Close overlay window before capturing
@@ -307,12 +316,12 @@ async fn save_captured_image(
 #[tauri::command]
 async fn check_capture_permission() -> Result<bool, String> {
     info!("check_capture_permission command called");
-    ScreenCapture::check_permission().map_err(|e| e.to_string())
+    check_permission_native().map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 fn get_virtual_screen_bounds() -> Rect {
-    ScreenCapture::get_virtual_screen_bounds()
+    get_virtual_screen_bounds_native()
 }
 
 fn main() {

--- a/wrapper/src-tauri/tauri.conf.json
+++ b/wrapper/src-tauri/tauri.conf.json
@@ -45,6 +45,20 @@
       },
       "path": {
         "all": true
+      },
+      "dialog": {
+        "all": false,
+        "save": true,
+        "open": false,
+        "message": false,
+        "ask": false,
+        "confirm": false
+      },
+      "window": {
+        "all": true
+      },
+      "globalShortcut": {
+        "all": true
       }
     },
     "bundle": {
@@ -111,6 +125,7 @@
     "updater": {
       "active": false
     },
-    "windows": []
+    "windows": [],
+    "macOSPrivateApi": true
   }
 }

--- a/wrapper/src-tauri/tests/capture_integration.rs
+++ b/wrapper/src-tauri/tests/capture_integration.rs
@@ -1,0 +1,369 @@
+//! Integration tests for the screen capture workflow
+//! Tests the end-to-end capture process using mock backend
+
+use porua_wrapper::capture::{
+    CaptureError, MockScreenBackend, MonitorInfo, Rect, ScreenCapture,
+};
+use tempfile::TempDir;
+
+/// Helper to create a test capture instance
+fn create_test_capture() -> (ScreenCapture<MockScreenBackend>, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let capture = ScreenCapture::with_backend(
+        MockScreenBackend::new(),
+        temp_dir.path().to_path_buf(),
+    );
+    (capture, temp_dir)
+}
+
+/// Helper to create a capture with custom backend
+fn create_capture_with_backend(backend: MockScreenBackend) -> (ScreenCapture<MockScreenBackend>, TempDir) {
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let capture = ScreenCapture::with_backend(backend, temp_dir.path().to_path_buf());
+    (capture, temp_dir)
+}
+
+// ==================== End-to-End Workflow Tests ====================
+
+#[test]
+fn test_capture_workflow_end_to_end() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    // 1. Verify we can get monitors
+    let monitors = capture.get_monitors().expect("Should get monitors");
+    assert!(!monitors.is_empty());
+
+    // 2. Verify we can get virtual screen bounds
+    let bounds = capture.get_virtual_screen_bounds();
+    assert!(bounds.width > 0);
+    assert!(bounds.height > 0);
+
+    // 3. Create a valid selection within bounds
+    let selection = Rect::new(100, 100, 200, 150);
+
+    // 4. Validate the selection
+    let validated = capture.validate_selection(selection).expect("Should validate");
+    assert_eq!(validated.width, 200);
+    assert_eq!(validated.height, 150);
+
+    // 5. Perform capture
+    let result = capture.capture_region(selection).expect("Capture should succeed");
+
+    // 6. Verify result
+    assert!(!result.file_path.is_empty());
+    assert!(std::path::Path::new(&result.file_path).exists());
+    assert!(!result.timestamp.is_empty());
+}
+
+#[test]
+fn test_capture_returns_valid_file_path() {
+    let (capture, temp_dir) = create_test_capture();
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    // File path should be absolute and exist
+    let path = std::path::Path::new(&result.file_path);
+    assert!(path.is_absolute() || result.file_path.starts_with(temp_dir.path().to_str().unwrap()));
+    assert!(path.exists());
+}
+
+#[test]
+fn test_capture_file_exists_after_completion() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(50, 50, 300, 200);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    // Verify file exists and is readable
+    let path = std::path::Path::new(&result.file_path);
+    assert!(path.exists(), "Captured file should exist");
+    assert!(path.is_file(), "Should be a file");
+
+    // Verify it's a valid image
+    let metadata = std::fs::metadata(path).expect("Should read metadata");
+    assert!(metadata.len() > 0, "File should not be empty");
+}
+
+#[test]
+fn test_capture_image_matches_selection_dimensions() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(0, 0, 320, 240);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    // Load and verify dimensions
+    let img = image::open(&result.file_path).expect("Should load image");
+    assert_eq!(img.width(), 320, "Width should match selection");
+    assert_eq!(img.height(), 240, "Height should match selection");
+}
+
+#[test]
+fn test_capture_with_dpi_scaling_adjusts_dimensions() {
+    let backend = MockScreenBackend::new().with_dpi_scale(1.5);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    // With 1.5x DPI, dimensions should be scaled
+    assert_eq!(result.width, 150, "Width should be scaled by DPI");
+    assert_eq!(result.height, 150, "Height should be scaled by DPI");
+}
+
+#[test]
+fn test_capture_handles_multi_monitor_coordinates() {
+    let monitors = vec![
+        MonitorInfo {
+            id: 0,
+            name: "Primary".to_string(),
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            dpi_scale: 1.0,
+            is_primary: true,
+        },
+        MonitorInfo {
+            id: 1,
+            name: "Secondary".to_string(),
+            x: 1920, // Right of primary
+            y: 0,
+            width: 1920,
+            height: 1080,
+            dpi_scale: 1.0,
+            is_primary: false,
+        },
+    ];
+
+    let backend = MockScreenBackend::new()
+        .with_monitors(monitors)
+        .with_virtual_bounds(Rect::new(0, 0, 3840, 1080));
+
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // Capture from second monitor (x starts at 1920)
+    let rect = Rect::new(2000, 100, 200, 200);
+    let result = capture.capture_region(rect);
+
+    assert!(result.is_ok(), "Should capture from second monitor");
+}
+
+#[test]
+fn test_capture_clamps_selection_spanning_monitors() {
+    let backend = MockScreenBackend::new()
+        .with_virtual_bounds(Rect::new(0, 0, 3840, 1080));
+
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // Selection that spans across monitor boundary
+    let rect = Rect::new(1800, 500, 400, 200);
+    let validated = capture.validate_selection(rect).expect("Should validate");
+
+    // Should be clamped to virtual screen bounds
+    assert!(validated.x + validated.width as i32 <= 3840);
+}
+
+// ==================== Validation Integration Tests ====================
+
+#[test]
+fn test_validation_rejects_too_small_selection() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(100, 100, 5, 5);
+    let result = capture.validate_selection(rect);
+
+    assert!(matches!(result, Err(CaptureError::SelectionTooSmall)));
+}
+
+#[test]
+fn test_validation_clamps_to_screen_bounds() {
+    let backend = MockScreenBackend::new()
+        .with_virtual_bounds(Rect::new(0, 0, 1920, 1080));
+
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // Selection extends past right edge
+    let rect = Rect::new(1800, 500, 300, 200);
+    let validated = capture.validate_selection(rect).expect("Should validate");
+
+    // Width should be clamped
+    assert_eq!(validated.x, 1800);
+    assert_eq!(validated.width, 120, "Width should be clamped to 1920-1800=120");
+}
+
+#[test]
+fn test_validation_handles_negative_coordinates() {
+    let backend = MockScreenBackend::new()
+        .with_virtual_bounds(Rect::new(0, 0, 1920, 1080));
+
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // Selection with negative start
+    let rect = Rect::new(-50, -30, 200, 200);
+    let validated = capture.validate_selection(rect).expect("Should validate");
+
+    assert_eq!(validated.x, 0, "X should be clamped to 0");
+    assert_eq!(validated.y, 0, "Y should be clamped to 0");
+}
+
+// ==================== Permission Tests ====================
+
+#[test]
+fn test_permission_check_integration() {
+    let backend = MockScreenBackend::new().with_permission(true);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let result = capture.check_permission();
+    assert!(result.is_ok());
+    assert!(result.unwrap());
+}
+
+#[test]
+fn test_permission_denied_prevents_capture_conceptually() {
+    let backend = MockScreenBackend::new().with_permission(false);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // Permission check should fail
+    let result = capture.check_permission();
+    assert!(matches!(result, Err(CaptureError::PermissionDenied)));
+
+    // Note: In real app, we'd check permission before capturing
+    // The mock still allows capture for testing purposes
+}
+
+// ==================== Error Handling Tests ====================
+
+#[test]
+fn test_capture_with_no_monitors_fails() {
+    let backend = MockScreenBackend::new().with_monitors(vec![]);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let result = capture.get_monitors();
+    assert!(matches!(result, Err(CaptureError::NoMonitors)));
+}
+
+#[test]
+fn test_multiple_captures_create_unique_files() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(0, 0, 50, 50);
+
+    let result1 = capture.capture_region(rect).expect("First capture");
+    let result2 = capture.capture_region(rect).expect("Second capture");
+    let result3 = capture.capture_region(rect).expect("Third capture");
+
+    // All file paths should be unique
+    assert_ne!(result1.file_path, result2.file_path);
+    assert_ne!(result2.file_path, result3.file_path);
+    assert_ne!(result1.file_path, result3.file_path);
+
+    // All files should exist
+    assert!(std::path::Path::new(&result1.file_path).exists());
+    assert!(std::path::Path::new(&result2.file_path).exists());
+    assert!(std::path::Path::new(&result3.file_path).exists());
+}
+
+// ==================== DPI Scaling Integration Tests ====================
+
+#[test]
+fn test_capture_at_100_percent_dpi() {
+    let backend = MockScreenBackend::new().with_dpi_scale(1.0);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    assert_eq!(result.width, 100);
+    assert_eq!(result.height, 100);
+}
+
+#[test]
+fn test_capture_at_125_percent_dpi() {
+    let backend = MockScreenBackend::new().with_dpi_scale(1.25);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    assert_eq!(result.width, 125);
+    assert_eq!(result.height, 125);
+}
+
+#[test]
+fn test_capture_at_150_percent_dpi() {
+    let backend = MockScreenBackend::new().with_dpi_scale(1.5);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    assert_eq!(result.width, 150);
+    assert_eq!(result.height, 150);
+}
+
+#[test]
+fn test_capture_at_200_percent_dpi() {
+    let backend = MockScreenBackend::new().with_dpi_scale(2.0);
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    assert_eq!(result.width, 200);
+    assert_eq!(result.height, 200);
+}
+
+// ==================== Timestamp Tests ====================
+
+#[test]
+fn test_capture_result_has_valid_timestamp() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(0, 0, 100, 100);
+    let result = capture.capture_region(rect).expect("Capture should succeed");
+
+    // Timestamp should be in format "YYYY-MM-DD HH:MM:SS"
+    assert!(!result.timestamp.is_empty());
+    assert!(result.timestamp.contains("-"), "Should have date separators");
+    assert!(result.timestamp.contains(":"), "Should have time separators");
+    assert_eq!(result.timestamp.len(), 19, "Should be 19 chars: YYYY-MM-DD HH:MM:SS");
+}
+
+// ==================== Stress Tests ====================
+
+#[test]
+fn test_rapid_successive_captures() {
+    let (capture, _temp_dir) = create_test_capture();
+
+    let rect = Rect::new(0, 0, 50, 50);
+
+    // Perform 10 rapid captures
+    let mut results = Vec::new();
+    for _ in 0..10 {
+        let result = capture.capture_region(rect).expect("Capture should succeed");
+        results.push(result);
+    }
+
+    // All should have unique file paths
+    let paths: std::collections::HashSet<_> = results.iter().map(|r| &r.file_path).collect();
+    assert_eq!(paths.len(), 10, "All captures should have unique paths");
+}
+
+#[test]
+fn test_large_selection_capture() {
+    let backend = MockScreenBackend::new()
+        .with_virtual_bounds(Rect::new(0, 0, 3840, 2160));
+
+    let (capture, _temp_dir) = create_capture_with_backend(backend);
+
+    // 4K capture
+    let rect = Rect::new(0, 0, 3840, 2160);
+    let result = capture.capture_region(rect).expect("Large capture should succeed");
+
+    assert_eq!(result.width, 3840);
+    assert_eq!(result.height, 2160);
+
+    // Verify file was created
+    assert!(std::path::Path::new(&result.file_path).exists());
+}

--- a/wrapper/src/overlay.css
+++ b/wrapper/src/overlay.css
@@ -134,6 +134,11 @@ html, body {
     opacity: 0;
     transition: opacity 0.3s ease, transform 0.3s ease;
     pointer-events: none;
+    cursor: pointer;
+}
+
+.toast.visible {
+    pointer-events: auto;
 }
 
 .toast.hidden {

--- a/wrapper/src/overlay.css
+++ b/wrapper/src/overlay.css
@@ -1,0 +1,198 @@
+/**
+ * Screen Capture Overlay Styles
+ */
+
+/* ==================== Base Styles ==================== */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+html, body {
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    background: transparent;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+}
+
+/* ==================== Canvas ==================== */
+
+#overlay-canvas {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    cursor: crosshair;
+    z-index: 1;
+}
+
+/* ==================== Dimension Tooltip ==================== */
+
+.tooltip {
+    position: fixed;
+    padding: 6px 10px;
+    background: rgba(33, 150, 243, 0.95);
+    color: white;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: 500;
+    font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+    pointer-events: none;
+    z-index: 100;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+    white-space: nowrap;
+    transition: opacity 0.15s ease;
+}
+
+.tooltip.hidden {
+    opacity: 0;
+    visibility: hidden;
+}
+
+/* ==================== Instructions Overlay ==================== */
+
+.instructions {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 50;
+    transition: opacity 0.3s ease;
+}
+
+.instructions.hidden {
+    opacity: 0;
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.instructions-content {
+    text-align: center;
+    color: white;
+    max-width: 400px;
+    padding: 40px;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+}
+
+.instructions-content h2 {
+    font-size: 28px;
+    font-weight: 600;
+    margin-bottom: 16px;
+    color: #fff;
+}
+
+.instructions-content p {
+    font-size: 16px;
+    margin-bottom: 12px;
+    color: rgba(255, 255, 255, 0.9);
+    line-height: 1.5;
+}
+
+.instructions-content .hint {
+    font-size: 13px;
+    color: rgba(255, 255, 255, 0.6);
+    margin-top: 20px;
+}
+
+.instructions-content kbd {
+    display: inline-block;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 4px;
+    font-family: 'Monaco', 'Menlo', 'Consolas', monospace;
+    font-size: 12px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
+}
+
+/* ==================== Error Toast ==================== */
+
+.toast {
+    position: fixed;
+    bottom: 40px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    padding: 12px 24px;
+    background: rgba(244, 67, 54, 0.95);
+    color: white;
+    border-radius: 8px;
+    font-size: 14px;
+    font-weight: 500;
+    z-index: 200;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    opacity: 0;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+    pointer-events: none;
+}
+
+.toast.hidden {
+    opacity: 0;
+    transform: translateX(-50%) translateY(20px);
+}
+
+.toast.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
+/* ==================== Animations ==================== */
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+/* ==================== High Contrast Mode ==================== */
+
+@media (prefers-contrast: high) {
+    .tooltip {
+        background: #1565C0;
+        border: 2px solid white;
+    }
+
+    .toast {
+        background: #C62828;
+        border: 2px solid white;
+    }
+
+    .instructions-content {
+        background: rgba(0, 0, 0, 0.9);
+        border: 2px solid white;
+    }
+}
+
+/* ==================== Reduced Motion ==================== */
+
+@media (prefers-reduced-motion: reduce) {
+    .tooltip,
+    .toast,
+    .instructions {
+        transition: none;
+    }
+}

--- a/wrapper/src/overlay.html
+++ b/wrapper/src/overlay.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Screen Capture</title>
+    <link rel="stylesheet" href="overlay.css">
+</head>
+<body>
+    <!-- Main canvas for rendering the selection overlay -->
+    <canvas id="overlay-canvas"></canvas>
+
+    <!-- Dimension tooltip that follows the cursor -->
+    <div id="dimension-tooltip" class="tooltip hidden">
+        <span id="tooltip-width">0</span> x <span id="tooltip-height">0</span>
+    </div>
+
+    <!-- Instructions overlay shown initially -->
+    <div id="instructions" class="instructions">
+        <div class="instructions-content">
+            <h2>Screen Capture</h2>
+            <p>Click and drag to select an area</p>
+            <p class="hint">Press <kbd>ESC</kbd> to cancel</p>
+        </div>
+    </div>
+
+    <!-- Error toast for displaying errors -->
+    <div id="error-toast" class="toast hidden">
+        <span id="toast-message"></span>
+    </div>
+
+    <script src="overlay.js"></script>
+</body>
+</html>

--- a/wrapper/src/overlay.js
+++ b/wrapper/src/overlay.js
@@ -17,11 +17,22 @@ const state = {
     currentPoint: null,
     selectionRect: null,
     animationFrameId: null,
-    instructionsVisible: true
+    instructionsVisible: true,
+    permissionChecked: false,
+    hasPermission: true
 };
 
 // Minimum selection size in pixels
 const MIN_SELECTION_SIZE = 10;
+
+// Error types for better user feedback
+const ErrorType = {
+    SELECTION_TOO_SMALL: 'selection_too_small',
+    PERMISSION_DENIED: 'permission_denied',
+    CAPTURE_FAILED: 'capture_failed',
+    SAVE_FAILED: 'save_failed',
+    UNKNOWN: 'unknown'
+};
 
 // ==================== DOM Elements ====================
 
@@ -31,12 +42,33 @@ let instructions, errorToast, toastMessage;
 
 // ==================== Initialization ====================
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
     initializeElements();
     initializeCanvas();
     attachEventListeners();
     startRenderLoop();
+    await checkCapturePermission();
 });
+
+/**
+ * Check if we have permission to capture screen
+ * On macOS, this requires Screen Recording permission
+ */
+async function checkCapturePermission() {
+    try {
+        state.hasPermission = await invoke('check_capture_permission');
+        state.permissionChecked = true;
+
+        if (!state.hasPermission) {
+            showError('Screen recording permission required. Please grant permission in System Preferences > Privacy & Security > Screen Recording.');
+        }
+    } catch (error) {
+        console.warn('Permission check failed:', error);
+        // Assume we have permission if check fails (Windows doesn't need it)
+        state.hasPermission = true;
+        state.permissionChecked = true;
+    }
+}
 
 function initializeElements() {
     canvas = document.getElementById('overlay-canvas');
@@ -145,25 +177,88 @@ function calculateRect(point1, point2) {
 }
 
 /**
+ * Check if selection meets minimum size requirements
+ */
+function isSelectionValid(rect) {
+    if (!rect) return false;
+    return rect.width >= MIN_SELECTION_SIZE && rect.height >= MIN_SELECTION_SIZE;
+}
+
+/**
+ * Check if selection is just a click (not a real drag)
+ */
+function isJustAClick(rect) {
+    if (!rect) return true;
+    return rect.width < 2 && rect.height < 2;
+}
+
+/**
+ * Parse error message and return appropriate user-friendly message
+ */
+function parseErrorMessage(error) {
+    const errorStr = error.toString().toLowerCase();
+
+    if (errorStr.includes('permission') || errorStr.includes('denied')) {
+        return {
+            type: ErrorType.PERMISSION_DENIED,
+            message: 'Screen recording permission denied. Please enable it in System Preferences.'
+        };
+    }
+
+    if (errorStr.includes('too small') || errorStr.includes('minimum')) {
+        return {
+            type: ErrorType.SELECTION_TOO_SMALL,
+            message: `Selection too small (minimum ${MIN_SELECTION_SIZE}x${MIN_SELECTION_SIZE}px)`
+        };
+    }
+
+    if (errorStr.includes('save') || errorStr.includes('write') || errorStr.includes('file')) {
+        return {
+            type: ErrorType.SAVE_FAILED,
+            message: 'Failed to save captured image. Check disk space and permissions.'
+        };
+    }
+
+    return {
+        type: ErrorType.CAPTURE_FAILED,
+        message: 'Failed to capture screen. Please try again.'
+    };
+}
+
+/**
  * Validate selection and trigger capture
  */
 async function completeSelection(rect) {
     // Check if this is just a click (no real drag)
-    if (rect.width < 2 && rect.height < 2) {
+    if (isJustAClick(rect)) {
         // Just a click, reset state and continue
         resetSelectionState();
         return;
     }
 
     // Check minimum size
-    if (rect.width < MIN_SELECTION_SIZE || rect.height < MIN_SELECTION_SIZE) {
+    if (!isSelectionValid(rect)) {
         showError(`Selection too small (minimum ${MIN_SELECTION_SIZE}x${MIN_SELECTION_SIZE}px)`);
+        resetSelectionState();
+        return;
+    }
+
+    // Check permission before attempting capture
+    if (!state.hasPermission) {
+        showError('Screen recording permission required. Please grant permission and try again.');
         resetSelectionState();
         return;
     }
 
     // Clamp to screen boundaries
     const clampedRect = clampToScreen(rect);
+
+    // Final validation after clamping
+    if (!isSelectionValid(clampedRect)) {
+        showError('Selection extends outside screen boundaries. Please select within visible area.');
+        resetSelectionState();
+        return;
+    }
 
     try {
         // Call Tauri backend to capture the region
@@ -174,6 +269,11 @@ async function completeSelection(rect) {
             height: Math.round(clampedRect.height)
         });
 
+        // Validate result
+        if (!result || !result.file_path) {
+            throw new Error('Capture returned invalid result');
+        }
+
         // Open preview window with the captured image
         await invoke('open_preview_window', {
             imagePath: result.file_path,
@@ -182,7 +282,8 @@ async function completeSelection(rect) {
 
     } catch (error) {
         console.error('Capture failed:', error);
-        showError('Failed to capture screen: ' + error);
+        const parsed = parseErrorMessage(error);
+        showError(parsed.message);
         resetSelectionState();
     }
 }
@@ -283,9 +384,13 @@ function drawDarkOverlay(rect) {
 
 /**
  * Draw selection rectangle border
+ * Shows red border if selection is too small
  */
 function drawSelectionBorder(rect) {
-    ctx.strokeStyle = '#2196F3';
+    const isTooSmall = !isSelectionValid(rect);
+
+    // Use red border if selection is too small
+    ctx.strokeStyle = isTooSmall ? '#f44336' : '#2196F3';
     ctx.lineWidth = 2;
     ctx.setLineDash([]);
     ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
@@ -298,10 +403,12 @@ function drawSelectionBorder(rect) {
 
 /**
  * Draw corner handles for visual feedback
+ * Shows red handles if selection is too small
  */
 function drawCornerHandles(rect) {
     const handleSize = 8;
-    ctx.fillStyle = '#2196F3';
+    const isTooSmall = !isSelectionValid(rect);
+    ctx.fillStyle = isTooSmall ? '#f44336' : '#2196F3';
 
     // Top-left
     ctx.fillRect(rect.x - handleSize/2, rect.y - handleSize/2, handleSize, handleSize);
@@ -376,7 +483,11 @@ if (typeof module !== 'undefined' && module.exports) {
     module.exports = {
         calculateRect,
         clampToScreen,
+        isSelectionValid,
+        isJustAClick,
+        parseErrorMessage,
         state,
-        MIN_SELECTION_SIZE
+        MIN_SELECTION_SIZE,
+        ErrorType
     };
 }

--- a/wrapper/src/overlay.js
+++ b/wrapper/src/overlay.js
@@ -281,9 +281,7 @@ async function completeSelection(rect) {
         });
 
     } catch (error) {
-        console.error('Capture failed:', error);
-        const parsed = parseErrorMessage(error);
-        showError(parsed.message);
+        handleError(error, 'completeSelection');
         resetSelectionState();
     }
 }
@@ -464,16 +462,45 @@ function updateTooltip(mouseX, mouseY, rect) {
     dimensionTooltip.style.top = tooltipY + 'px';
 }
 
-function showError(message) {
+/**
+ * Show error toast with user-friendly message
+ * Errors are auto-hidden after a delay and can be dismissed by clicking
+ */
+function showError(message, persistent = false) {
     toastMessage.textContent = message;
     errorToast.classList.remove('hidden');
     errorToast.classList.add('visible');
 
-    // Auto-hide after 3 seconds
+    // Make toast clickable to dismiss
+    const dismissHandler = () => {
+        errorToast.classList.remove('visible');
+        errorToast.classList.add('hidden');
+        errorToast.removeEventListener('click', dismissHandler);
+    };
+    errorToast.addEventListener('click', dismissHandler);
+
+    // Auto-hide after delay (longer for permission errors)
+    const hideDelay = persistent ? 6000 : 3000;
     setTimeout(() => {
         errorToast.classList.remove('visible');
         errorToast.classList.add('hidden');
-    }, 3000);
+        errorToast.removeEventListener('click', dismissHandler);
+    }, hideDelay);
+}
+
+/**
+ * Log error details to console for debugging
+ * while showing user-friendly message
+ */
+function handleError(error, context = '') {
+    console.error(`[Screen Capture${context ? ': ' + context : ''}]`, error);
+    const parsed = parseErrorMessage(error);
+
+    // Permission errors need longer display time
+    const persistent = parsed.type === ErrorType.PERMISSION_DENIED;
+    showError(parsed.message, persistent);
+
+    return parsed;
 }
 
 // ==================== Exports for Testing ====================
@@ -486,6 +513,8 @@ if (typeof module !== 'undefined' && module.exports) {
         isSelectionValid,
         isJustAClick,
         parseErrorMessage,
+        handleError,
+        showError,
         state,
         MIN_SELECTION_SIZE,
         ErrorType

--- a/wrapper/src/overlay.js
+++ b/wrapper/src/overlay.js
@@ -1,0 +1,382 @@
+/**
+ * Screen Capture Overlay
+ * Handles mouse-based rectangular selection for screen capture
+ */
+
+// Tauri API - only available in Tauri environment
+const invoke = (typeof window !== 'undefined' && window.__TAURI__)
+    ? window.__TAURI__.invoke
+    : async () => { throw new Error('Tauri not available'); };
+
+// ==================== Selection State ====================
+
+const state = {
+    isSelecting: false,
+    isDragging: false,
+    startPoint: null,
+    currentPoint: null,
+    selectionRect: null,
+    animationFrameId: null,
+    instructionsVisible: true
+};
+
+// Minimum selection size in pixels
+const MIN_SELECTION_SIZE = 10;
+
+// ==================== DOM Elements ====================
+
+let canvas, ctx;
+let dimensionTooltip, tooltipWidth, tooltipHeight;
+let instructions, errorToast, toastMessage;
+
+// ==================== Initialization ====================
+
+document.addEventListener('DOMContentLoaded', () => {
+    initializeElements();
+    initializeCanvas();
+    attachEventListeners();
+    startRenderLoop();
+});
+
+function initializeElements() {
+    canvas = document.getElementById('overlay-canvas');
+    ctx = canvas.getContext('2d');
+
+    dimensionTooltip = document.getElementById('dimension-tooltip');
+    tooltipWidth = document.getElementById('tooltip-width');
+    tooltipHeight = document.getElementById('tooltip-height');
+
+    instructions = document.getElementById('instructions');
+    errorToast = document.getElementById('error-toast');
+    toastMessage = document.getElementById('toast-message');
+}
+
+function initializeCanvas() {
+    // Set canvas to full window size
+    resizeCanvas();
+    window.addEventListener('resize', resizeCanvas);
+}
+
+function resizeCanvas() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+}
+
+function attachEventListeners() {
+    // Mouse events
+    canvas.addEventListener('mousedown', handleMouseDown);
+    canvas.addEventListener('mousemove', handleMouseMove);
+    canvas.addEventListener('mouseup', handleMouseUp);
+
+    // Keyboard events
+    document.addEventListener('keydown', handleKeyDown);
+
+    // Prevent context menu
+    canvas.addEventListener('contextmenu', (e) => e.preventDefault());
+}
+
+// ==================== Event Handlers ====================
+
+function handleMouseDown(e) {
+    if (e.button !== 0) return; // Only left click
+
+    // Hide instructions on first interaction
+    if (state.instructionsVisible) {
+        hideInstructions();
+    }
+
+    state.isSelecting = true;
+    state.isDragging = true;
+    state.startPoint = { x: e.clientX, y: e.clientY };
+    state.currentPoint = { x: e.clientX, y: e.clientY };
+    state.selectionRect = null;
+
+    // Show tooltip
+    showTooltip();
+}
+
+function handleMouseMove(e) {
+    if (!state.isDragging) return;
+
+    state.currentPoint = { x: e.clientX, y: e.clientY };
+    state.selectionRect = calculateRect(state.startPoint, state.currentPoint);
+
+    // Update tooltip position and values
+    updateTooltip(e.clientX, e.clientY, state.selectionRect);
+}
+
+function handleMouseUp(e) {
+    if (!state.isDragging) return;
+
+    state.isDragging = false;
+    state.currentPoint = { x: e.clientX, y: e.clientY };
+    state.selectionRect = calculateRect(state.startPoint, state.currentPoint);
+
+    // Hide tooltip
+    hideTooltip();
+
+    // Validate and complete selection
+    if (state.selectionRect) {
+        completeSelection(state.selectionRect);
+    }
+}
+
+function handleKeyDown(e) {
+    if (e.key === 'Escape') {
+        cancelCapture();
+    }
+}
+
+// ==================== Selection Logic ====================
+
+/**
+ * Calculate rectangle from two corner points
+ * Handles any drag direction (top-left to bottom-right, etc.)
+ */
+function calculateRect(point1, point2) {
+    if (!point1 || !point2) return null;
+
+    const x = Math.min(point1.x, point2.x);
+    const y = Math.min(point1.y, point2.y);
+    const width = Math.abs(point2.x - point1.x);
+    const height = Math.abs(point2.y - point1.y);
+
+    return { x, y, width, height };
+}
+
+/**
+ * Validate selection and trigger capture
+ */
+async function completeSelection(rect) {
+    // Check if this is just a click (no real drag)
+    if (rect.width < 2 && rect.height < 2) {
+        // Just a click, reset state and continue
+        resetSelectionState();
+        return;
+    }
+
+    // Check minimum size
+    if (rect.width < MIN_SELECTION_SIZE || rect.height < MIN_SELECTION_SIZE) {
+        showError(`Selection too small (minimum ${MIN_SELECTION_SIZE}x${MIN_SELECTION_SIZE}px)`);
+        resetSelectionState();
+        return;
+    }
+
+    // Clamp to screen boundaries
+    const clampedRect = clampToScreen(rect);
+
+    try {
+        // Call Tauri backend to capture the region
+        const result = await invoke('capture_screen_region', {
+            x: Math.round(clampedRect.x),
+            y: Math.round(clampedRect.y),
+            width: Math.round(clampedRect.width),
+            height: Math.round(clampedRect.height)
+        });
+
+        // Open preview window with the captured image
+        await invoke('open_preview_window', {
+            imagePath: result.file_path,
+            timestamp: result.timestamp
+        });
+
+    } catch (error) {
+        console.error('Capture failed:', error);
+        showError('Failed to capture screen: ' + error);
+        resetSelectionState();
+    }
+}
+
+/**
+ * Clamp rectangle to screen boundaries
+ */
+function clampToScreen(rect) {
+    const x = Math.max(0, rect.x);
+    const y = Math.max(0, rect.y);
+    const right = Math.min(window.innerWidth, rect.x + rect.width);
+    const bottom = Math.min(window.innerHeight, rect.y + rect.height);
+
+    return {
+        x: x,
+        y: y,
+        width: Math.max(0, right - x),
+        height: Math.max(0, bottom - y)
+    };
+}
+
+/**
+ * Reset selection state for new selection
+ */
+function resetSelectionState() {
+    state.isSelecting = false;
+    state.isDragging = false;
+    state.startPoint = null;
+    state.currentPoint = null;
+    state.selectionRect = null;
+}
+
+/**
+ * Cancel capture and close overlay
+ */
+async function cancelCapture() {
+    try {
+        await invoke('cancel_capture');
+    } catch (error) {
+        console.error('Failed to cancel capture:', error);
+    }
+}
+
+// ==================== Rendering ====================
+
+/**
+ * Start the render loop for smooth 60fps updates
+ */
+function startRenderLoop() {
+    function render() {
+        drawOverlay();
+        state.animationFrameId = requestAnimationFrame(render);
+    }
+    render();
+}
+
+/**
+ * Main drawing function
+ */
+function drawOverlay() {
+    // Clear canvas
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+    if (state.isDragging && state.selectionRect) {
+        // Draw semi-transparent dark overlay
+        drawDarkOverlay(state.selectionRect);
+
+        // Draw selection rectangle border
+        drawSelectionBorder(state.selectionRect);
+
+        // Draw corner handles
+        drawCornerHandles(state.selectionRect);
+    } else if (!state.instructionsVisible) {
+        // When not selecting but instructions hidden, show light overlay
+        ctx.fillStyle = 'rgba(0, 0, 0, 0.1)';
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+    }
+}
+
+/**
+ * Draw dark overlay with transparent selection cutout
+ */
+function drawDarkOverlay(rect) {
+    ctx.fillStyle = 'rgba(0, 0, 0, 0.5)';
+
+    // Top region
+    ctx.fillRect(0, 0, canvas.width, rect.y);
+
+    // Bottom region
+    ctx.fillRect(0, rect.y + rect.height, canvas.width, canvas.height - rect.y - rect.height);
+
+    // Left region
+    ctx.fillRect(0, rect.y, rect.x, rect.height);
+
+    // Right region
+    ctx.fillRect(rect.x + rect.width, rect.y, canvas.width - rect.x - rect.width, rect.height);
+}
+
+/**
+ * Draw selection rectangle border
+ */
+function drawSelectionBorder(rect) {
+    ctx.strokeStyle = '#2196F3';
+    ctx.lineWidth = 2;
+    ctx.setLineDash([]);
+    ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
+
+    // Inner white border for contrast
+    ctx.strokeStyle = 'rgba(255, 255, 255, 0.8)';
+    ctx.lineWidth = 1;
+    ctx.strokeRect(rect.x + 1, rect.y + 1, rect.width - 2, rect.height - 2);
+}
+
+/**
+ * Draw corner handles for visual feedback
+ */
+function drawCornerHandles(rect) {
+    const handleSize = 8;
+    ctx.fillStyle = '#2196F3';
+
+    // Top-left
+    ctx.fillRect(rect.x - handleSize/2, rect.y - handleSize/2, handleSize, handleSize);
+
+    // Top-right
+    ctx.fillRect(rect.x + rect.width - handleSize/2, rect.y - handleSize/2, handleSize, handleSize);
+
+    // Bottom-left
+    ctx.fillRect(rect.x - handleSize/2, rect.y + rect.height - handleSize/2, handleSize, handleSize);
+
+    // Bottom-right
+    ctx.fillRect(rect.x + rect.width - handleSize/2, rect.y + rect.height - handleSize/2, handleSize, handleSize);
+}
+
+// ==================== UI Helpers ====================
+
+function hideInstructions() {
+    state.instructionsVisible = false;
+    instructions.classList.add('hidden');
+}
+
+function showTooltip() {
+    dimensionTooltip.classList.remove('hidden');
+}
+
+function hideTooltip() {
+    dimensionTooltip.classList.add('hidden');
+}
+
+function updateTooltip(mouseX, mouseY, rect) {
+    if (!rect) return;
+
+    // Update dimension values
+    tooltipWidth.textContent = Math.round(rect.width);
+    tooltipHeight.textContent = Math.round(rect.height);
+
+    // Position tooltip near cursor but offset to not obscure
+    const offsetX = 15;
+    const offsetY = 15;
+    let tooltipX = mouseX + offsetX;
+    let tooltipY = mouseY + offsetY;
+
+    // Keep tooltip on screen
+    const tooltipRect = dimensionTooltip.getBoundingClientRect();
+    if (tooltipX + tooltipRect.width > window.innerWidth) {
+        tooltipX = mouseX - tooltipRect.width - offsetX;
+    }
+    if (tooltipY + tooltipRect.height > window.innerHeight) {
+        tooltipY = mouseY - tooltipRect.height - offsetY;
+    }
+
+    dimensionTooltip.style.left = tooltipX + 'px';
+    dimensionTooltip.style.top = tooltipY + 'px';
+}
+
+function showError(message) {
+    toastMessage.textContent = message;
+    errorToast.classList.remove('hidden');
+    errorToast.classList.add('visible');
+
+    // Auto-hide after 3 seconds
+    setTimeout(() => {
+        errorToast.classList.remove('visible');
+        errorToast.classList.add('hidden');
+    }, 3000);
+}
+
+// ==================== Exports for Testing ====================
+
+// Export functions for unit testing (if in test environment)
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        calculateRect,
+        clampToScreen,
+        state,
+        MIN_SELECTION_SIZE
+    };
+}

--- a/wrapper/src/preview.css
+++ b/wrapper/src/preview.css
@@ -1,0 +1,292 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    background-color: #1a1a1a;
+    color: #ffffff;
+    overflow: hidden;
+    height: 100vh;
+    user-select: none;
+}
+
+#preview-container {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    position: relative;
+}
+
+#image-wrapper {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: auto;
+    background-color: #0d0d0d;
+    background-image:
+        linear-gradient(45deg, #1a1a1a 25%, transparent 25%),
+        linear-gradient(-45deg, #1a1a1a 25%, transparent 25%),
+        linear-gradient(45deg, transparent 75%, #1a1a1a 75%),
+        linear-gradient(-45deg, transparent 75%, #1a1a1a 75%);
+    background-size: 20px 20px;
+    background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+    position: relative;
+    cursor: grab;
+}
+
+#image-wrapper:active {
+    cursor: grabbing;
+}
+
+#preview-image {
+    max-width: none;
+    max-height: none;
+    display: block;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.5);
+    transition: transform 0.1s ease-out;
+}
+
+#preview-image.hidden {
+    display: none;
+}
+
+#loading-indicator {
+    position: absolute;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    color: #888;
+}
+
+#loading-indicator.hidden {
+    display: none;
+}
+
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 3px solid #333;
+    border-top-color: #007acc;
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+#toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 16px;
+    background-color: #2d2d2d;
+    border-top: 1px solid #404040;
+}
+
+#image-info {
+    display: flex;
+    gap: 16px;
+    font-size: 13px;
+    color: #aaa;
+}
+
+#image-info span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+}
+
+#actions {
+    display: flex;
+    gap: 8px;
+}
+
+.btn {
+    padding: 8px 16px;
+    border: none;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.btn:focus {
+    outline: 2px solid #007acc;
+    outline-offset: 2px;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.btn-primary {
+    background-color: #007acc;
+    color: white;
+}
+
+.btn-primary:hover:not(:disabled) {
+    background-color: #0098ff;
+}
+
+.btn-primary:active:not(:disabled) {
+    background-color: #005a9e;
+}
+
+.btn-secondary {
+    background-color: #404040;
+    color: #fff;
+}
+
+.btn-secondary:hover:not(:disabled) {
+    background-color: #505050;
+}
+
+.btn-secondary:active:not(:disabled) {
+    background-color: #333;
+}
+
+#zoom-controls {
+    position: absolute;
+    bottom: 70px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background-color: rgba(45, 45, 45, 0.95);
+    border-radius: 6px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+.zoom-btn {
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: 4px;
+    background-color: #404040;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.zoom-btn:hover {
+    background-color: #505050;
+}
+
+.zoom-btn:active {
+    background-color: #333;
+}
+
+#zoom-level {
+    min-width: 50px;
+    text-align: center;
+    font-size: 13px;
+    color: #aaa;
+}
+
+.toast {
+    position: absolute;
+    bottom: 130px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 10px 20px;
+    background-color: rgba(220, 53, 69, 0.95);
+    color: white;
+    border-radius: 6px;
+    font-size: 14px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+    animation: slideUp 0.3s ease;
+    z-index: 100;
+}
+
+.toast-success {
+    background-color: rgba(40, 167, 69, 0.95);
+}
+
+.toast.hidden {
+    display: none;
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(10px);
+    }
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
+    }
+}
+
+/* Keyboard shortcut hints */
+.btn::after {
+    content: attr(title);
+    position: absolute;
+    bottom: -30px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 4px 8px;
+    background-color: #222;
+    color: #888;
+    font-size: 11px;
+    border-radius: 3px;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.btn:hover::after {
+    opacity: 0;
+}
+
+/* Scrollbar styling */
+#image-wrapper::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+}
+
+#image-wrapper::-webkit-scrollbar-track {
+    background: #1a1a1a;
+}
+
+#image-wrapper::-webkit-scrollbar-thumb {
+    background: #404040;
+    border-radius: 5px;
+}
+
+#image-wrapper::-webkit-scrollbar-thumb:hover {
+    background: #505050;
+}
+
+/* Responsive adjustments */
+@media (max-width: 600px) {
+    #toolbar {
+        flex-direction: column;
+        gap: 12px;
+    }
+
+    #image-info {
+        order: 2;
+    }
+
+    #actions {
+        order: 1;
+    }
+}

--- a/wrapper/src/preview.html
+++ b/wrapper/src/preview.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Capture Preview</title>
+    <link rel="stylesheet" href="preview.css">
+</head>
+<body>
+    <div id="preview-container">
+        <div id="image-wrapper">
+            <img id="preview-image" alt="Captured screenshot" />
+            <div id="loading-indicator">
+                <div class="spinner"></div>
+                <span>Loading image...</span>
+            </div>
+        </div>
+
+        <div id="toolbar">
+            <div id="image-info">
+                <span id="dimensions"></span>
+                <span id="file-size"></span>
+            </div>
+
+            <div id="actions">
+                <button id="btn-recapture" class="btn btn-secondary" title="Take another capture (R)">
+                    Recapture
+                </button>
+                <button id="btn-save" class="btn btn-primary" title="Save to file (Ctrl+S)">
+                    Save As...
+                </button>
+                <button id="btn-close" class="btn btn-secondary" title="Close preview (Esc)">
+                    Close
+                </button>
+            </div>
+        </div>
+
+        <div id="zoom-controls">
+            <button id="btn-zoom-out" class="zoom-btn" title="Zoom out (-)">-</button>
+            <span id="zoom-level">100%</span>
+            <button id="btn-zoom-in" class="zoom-btn" title="Zoom in (+)">+</button>
+            <button id="btn-zoom-fit" class="zoom-btn" title="Fit to window (F)">Fit</button>
+            <button id="btn-zoom-actual" class="zoom-btn" title="Actual size (1)">1:1</button>
+        </div>
+
+        <div id="error-toast" class="toast hidden">
+            <span id="error-message"></span>
+        </div>
+
+        <div id="success-toast" class="toast toast-success hidden">
+            <span id="success-message"></span>
+        </div>
+    </div>
+
+    <script src="preview.js"></script>
+</body>
+</html>

--- a/wrapper/src/preview.js
+++ b/wrapper/src/preview.js
@@ -1,0 +1,475 @@
+/**
+ * Preview Window Logic
+ * Handles image display, zoom controls, and user actions
+ */
+
+// Tauri API - gracefully handle non-Tauri environments (for testing)
+const invoke = (typeof window !== 'undefined' && window.__TAURI__)
+    ? window.__TAURI__.invoke
+    : async () => { throw new Error('Tauri not available'); };
+
+const listen = (typeof window !== 'undefined' && window.__TAURI__ && window.__TAURI__.event)
+    ? window.__TAURI__.event.listen
+    : async () => ({ unlisten: () => {} });
+
+// Constants
+const MIN_ZOOM = 0.1;
+const MAX_ZOOM = 5.0;
+const ZOOM_STEP = 0.25;
+const DEFAULT_ZOOM = 1.0;
+
+// State
+const state = {
+    imagePath: null,
+    imageWidth: 0,
+    imageHeight: 0,
+    fileSize: 0,
+    zoom: DEFAULT_ZOOM,
+    isPanning: false,
+    panStart: { x: 0, y: 0 },
+    scrollStart: { x: 0, y: 0 }
+};
+
+// DOM Elements (initialized on DOMContentLoaded)
+let elements = {};
+
+/**
+ * Initialize DOM element references
+ */
+function initElements() {
+    elements = {
+        container: document.getElementById('preview-container'),
+        imageWrapper: document.getElementById('image-wrapper'),
+        image: document.getElementById('preview-image'),
+        loading: document.getElementById('loading-indicator'),
+        dimensions: document.getElementById('dimensions'),
+        fileSize: document.getElementById('file-size'),
+        zoomLevel: document.getElementById('zoom-level'),
+        btnZoomIn: document.getElementById('btn-zoom-in'),
+        btnZoomOut: document.getElementById('btn-zoom-out'),
+        btnZoomFit: document.getElementById('btn-zoom-fit'),
+        btnZoomActual: document.getElementById('btn-zoom-actual'),
+        btnRecapture: document.getElementById('btn-recapture'),
+        btnSave: document.getElementById('btn-save'),
+        btnClose: document.getElementById('btn-close'),
+        errorToast: document.getElementById('error-toast'),
+        errorMessage: document.getElementById('error-message'),
+        successToast: document.getElementById('success-toast'),
+        successMessage: document.getElementById('success-message')
+    };
+}
+
+/**
+ * Format file size in human-readable format
+ */
+function formatFileSize(bytes) {
+    if (bytes === 0) return '0 B';
+    const k = 1024;
+    const sizes = ['B', 'KB', 'MB', 'GB'];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + ' ' + sizes[i];
+}
+
+/**
+ * Update zoom level display
+ */
+function updateZoomDisplay() {
+    if (elements.zoomLevel) {
+        elements.zoomLevel.textContent = Math.round(state.zoom * 100) + '%';
+    }
+}
+
+/**
+ * Apply current zoom level to image
+ */
+function applyZoom() {
+    if (elements.image) {
+        const scaledWidth = state.imageWidth * state.zoom;
+        const scaledHeight = state.imageHeight * state.zoom;
+        elements.image.style.width = scaledWidth + 'px';
+        elements.image.style.height = scaledHeight + 'px';
+    }
+    updateZoomDisplay();
+}
+
+/**
+ * Set zoom level with bounds checking
+ */
+function setZoom(newZoom) {
+    state.zoom = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, newZoom));
+    applyZoom();
+}
+
+/**
+ * Zoom in by step amount
+ */
+function zoomIn() {
+    setZoom(state.zoom + ZOOM_STEP);
+}
+
+/**
+ * Zoom out by step amount
+ */
+function zoomOut() {
+    setZoom(state.zoom - ZOOM_STEP);
+}
+
+/**
+ * Fit image to window
+ */
+function zoomFit() {
+    if (!elements.imageWrapper || state.imageWidth === 0 || state.imageHeight === 0) return;
+
+    const wrapperRect = elements.imageWrapper.getBoundingClientRect();
+    const padding = 40; // Padding around image
+
+    const availableWidth = wrapperRect.width - padding;
+    const availableHeight = wrapperRect.height - padding;
+
+    const scaleX = availableWidth / state.imageWidth;
+    const scaleY = availableHeight / state.imageHeight;
+
+    setZoom(Math.min(scaleX, scaleY, 1.0)); // Don't zoom in beyond 100% for fit
+}
+
+/**
+ * Set zoom to actual size (100%)
+ */
+function zoomActual() {
+    setZoom(DEFAULT_ZOOM);
+}
+
+/**
+ * Load image from file path
+ */
+async function loadImage(imagePath) {
+    state.imagePath = imagePath;
+
+    // Show loading indicator
+    if (elements.loading) elements.loading.classList.remove('hidden');
+    if (elements.image) elements.image.classList.add('hidden');
+
+    try {
+        // Convert file path to file:// URL for the image
+        const imageUrl = convertFilePath(imagePath);
+
+        // Create a new image to get dimensions
+        const img = new Image();
+
+        await new Promise((resolve, reject) => {
+            img.onload = resolve;
+            img.onerror = () => reject(new Error('Failed to load image'));
+            img.src = imageUrl;
+        });
+
+        state.imageWidth = img.naturalWidth;
+        state.imageHeight = img.naturalHeight;
+
+        // Update UI
+        if (elements.image) {
+            elements.image.src = imageUrl;
+            elements.image.classList.remove('hidden');
+        }
+
+        if (elements.dimensions) {
+            elements.dimensions.textContent = `${state.imageWidth} x ${state.imageHeight} px`;
+        }
+
+        // Try to get file size (may not work in all contexts)
+        await updateFileSize(imagePath);
+
+        // Fit image to window initially
+        zoomFit();
+
+    } catch (error) {
+        showError('Failed to load image: ' + error.message);
+    } finally {
+        if (elements.loading) elements.loading.classList.add('hidden');
+    }
+}
+
+/**
+ * Convert file path to appropriate URL format
+ */
+function convertFilePath(filePath) {
+    // Handle Windows and Unix paths
+    if (filePath.startsWith('/')) {
+        return 'file://' + filePath;
+    } else if (/^[a-zA-Z]:/.test(filePath)) {
+        // Windows path
+        return 'file:///' + filePath.replace(/\\/g, '/');
+    }
+    return filePath;
+}
+
+/**
+ * Update file size display
+ */
+async function updateFileSize(filePath) {
+    // File size would need to be passed from backend or fetched
+    // For now, we'll leave it empty or get it via invoke
+    try {
+        // This would need a backend command to get file size
+        // For now just show placeholder
+        if (elements.fileSize) {
+            elements.fileSize.textContent = '';
+        }
+    } catch (e) {
+        // Ignore file size errors
+    }
+}
+
+/**
+ * Handle recapture button - start new capture
+ */
+async function handleRecapture() {
+    try {
+        // Close this preview and start new capture
+        await invoke('start_capture_mode');
+    } catch (error) {
+        showError('Failed to start capture: ' + error.message);
+    }
+}
+
+/**
+ * Handle save button - save image to user-selected location
+ */
+async function handleSave() {
+    if (!state.imagePath) {
+        showError('No image to save');
+        return;
+    }
+
+    try {
+        const savedPath = await invoke('save_captured_image', {
+            sourcePath: state.imagePath
+        });
+        showSuccess('Image saved to: ' + savedPath);
+    } catch (error) {
+        if (error.toString().includes('cancelled')) {
+            // User cancelled, not an error
+            return;
+        }
+        showError('Failed to save image: ' + error.message);
+    }
+}
+
+/**
+ * Handle close button - close preview window
+ */
+async function handleClose() {
+    try {
+        await invoke('cancel_capture');
+    } catch (error) {
+        // If invoke fails, try to close window directly
+        if (window.__TAURI__ && window.__TAURI__.window) {
+            const currentWindow = window.__TAURI__.window.getCurrent();
+            await currentWindow.close();
+        }
+    }
+}
+
+/**
+ * Show error toast
+ */
+function showError(message) {
+    if (elements.errorMessage) {
+        elements.errorMessage.textContent = message;
+    }
+    if (elements.errorToast) {
+        elements.errorToast.classList.remove('hidden');
+        setTimeout(() => {
+            elements.errorToast.classList.add('hidden');
+        }, 4000);
+    }
+}
+
+/**
+ * Show success toast
+ */
+function showSuccess(message) {
+    if (elements.successMessage) {
+        elements.successMessage.textContent = message;
+    }
+    if (elements.successToast) {
+        elements.successToast.classList.remove('hidden');
+        setTimeout(() => {
+            elements.successToast.classList.add('hidden');
+        }, 3000);
+    }
+}
+
+/**
+ * Handle mouse wheel zoom
+ */
+function handleWheel(event) {
+    event.preventDefault();
+
+    if (event.deltaY < 0) {
+        zoomIn();
+    } else {
+        zoomOut();
+    }
+}
+
+/**
+ * Handle pan start
+ */
+function handlePanStart(event) {
+    if (event.button !== 0) return; // Only left mouse button
+
+    state.isPanning = true;
+    state.panStart = { x: event.clientX, y: event.clientY };
+    state.scrollStart = {
+        x: elements.imageWrapper.scrollLeft,
+        y: elements.imageWrapper.scrollTop
+    };
+
+    event.preventDefault();
+}
+
+/**
+ * Handle pan move
+ */
+function handlePanMove(event) {
+    if (!state.isPanning) return;
+
+    const dx = event.clientX - state.panStart.x;
+    const dy = event.clientY - state.panStart.y;
+
+    elements.imageWrapper.scrollLeft = state.scrollStart.x - dx;
+    elements.imageWrapper.scrollTop = state.scrollStart.y - dy;
+}
+
+/**
+ * Handle pan end
+ */
+function handlePanEnd() {
+    state.isPanning = false;
+}
+
+/**
+ * Handle keyboard shortcuts
+ */
+function handleKeyDown(event) {
+    // Prevent default for our shortcuts
+    switch (event.key) {
+        case 'Escape':
+            event.preventDefault();
+            handleClose();
+            break;
+        case 'r':
+        case 'R':
+            event.preventDefault();
+            handleRecapture();
+            break;
+        case 's':
+        case 'S':
+            if (event.ctrlKey || event.metaKey) {
+                event.preventDefault();
+                handleSave();
+            }
+            break;
+        case '+':
+        case '=':
+            event.preventDefault();
+            zoomIn();
+            break;
+        case '-':
+        case '_':
+            event.preventDefault();
+            zoomOut();
+            break;
+        case 'f':
+        case 'F':
+            event.preventDefault();
+            zoomFit();
+            break;
+        case '1':
+            event.preventDefault();
+            zoomActual();
+            break;
+        case '0':
+            event.preventDefault();
+            zoomFit();
+            break;
+    }
+}
+
+/**
+ * Setup event listeners
+ */
+function setupEventListeners() {
+    // Button clicks
+    if (elements.btnZoomIn) elements.btnZoomIn.addEventListener('click', zoomIn);
+    if (elements.btnZoomOut) elements.btnZoomOut.addEventListener('click', zoomOut);
+    if (elements.btnZoomFit) elements.btnZoomFit.addEventListener('click', zoomFit);
+    if (elements.btnZoomActual) elements.btnZoomActual.addEventListener('click', zoomActual);
+    if (elements.btnRecapture) elements.btnRecapture.addEventListener('click', handleRecapture);
+    if (elements.btnSave) elements.btnSave.addEventListener('click', handleSave);
+    if (elements.btnClose) elements.btnClose.addEventListener('click', handleClose);
+
+    // Mouse wheel zoom
+    if (elements.imageWrapper) {
+        elements.imageWrapper.addEventListener('wheel', handleWheel, { passive: false });
+
+        // Pan with mouse drag
+        elements.imageWrapper.addEventListener('mousedown', handlePanStart);
+        document.addEventListener('mousemove', handlePanMove);
+        document.addEventListener('mouseup', handlePanEnd);
+    }
+
+    // Keyboard shortcuts
+    document.addEventListener('keydown', handleKeyDown);
+}
+
+/**
+ * Setup Tauri event listeners
+ */
+async function setupTauriListeners() {
+    // Listen for load-image event from backend
+    await listen('load-image', (event) => {
+        loadImage(event.payload);
+    });
+}
+
+/**
+ * Initialize the preview window
+ */
+async function init() {
+    initElements();
+    setupEventListeners();
+    await setupTauriListeners();
+}
+
+// Initialize on DOM ready
+if (typeof document !== 'undefined') {
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+}
+
+// Export for testing
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = {
+        state,
+        formatFileSize,
+        setZoom,
+        zoomIn,
+        zoomOut,
+        zoomFit,
+        zoomActual,
+        convertFilePath,
+        showError,
+        showSuccess,
+        MIN_ZOOM,
+        MAX_ZOOM,
+        ZOOM_STEP,
+        DEFAULT_ZOOM,
+        initElements,
+        loadImage,
+        handleKeyDown
+    };
+}

--- a/wrapper/src/tests/capture_e2e.test.js
+++ b/wrapper/src/tests/capture_e2e.test.js
@@ -1,0 +1,253 @@
+/**
+ * End-to-End Tests for Capture Workflow
+ * Tests the integration between frontend selection and backend capture
+ */
+
+// Import overlay functions
+const {
+    calculateRect,
+    clampToScreen,
+    state,
+    MIN_SELECTION_SIZE
+} = require('../overlay.js');
+
+// Mock Tauri invoke responses
+const mockCaptureResult = {
+    file_path: '/tmp/capture_20231118_120000_abc123.png',
+    width: 200,
+    height: 150,
+    timestamp: '2023-11-18 12:00:00'
+};
+
+describe('Capture Workflow E2E', () => {
+
+    beforeEach(() => {
+        // Reset mocks before each test
+        window.__TAURI__.invoke.mockReset();
+        window.__TAURI__.invoke.mockResolvedValue(mockCaptureResult);
+    });
+
+    describe('Selection to Capture Flow', () => {
+
+        test('valid selection produces correct capture parameters', async () => {
+            const startPoint = { x: 100, y: 100 };
+            const endPoint = { x: 300, y: 250 };
+
+            const rect = calculateRect(startPoint, endPoint);
+
+            expect(rect.x).toBe(100);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(150);
+
+            // These would be the parameters sent to capture_screen_region
+            expect(rect.width).toBeGreaterThanOrEqual(MIN_SELECTION_SIZE);
+            expect(rect.height).toBeGreaterThanOrEqual(MIN_SELECTION_SIZE);
+        });
+
+        test('selection is clamped before capture', () => {
+            // Selection extending past screen bounds
+            const rect = { x: 1800, y: 900, width: 300, height: 300 };
+            const clamped = clampToScreen(rect);
+
+            // Should be clamped to screen bounds (1920x1080)
+            expect(clamped.x).toBe(1800);
+            expect(clamped.y).toBe(900);
+            expect(clamped.width).toBe(120); // 1920 - 1800
+            expect(clamped.height).toBe(180); // 1080 - 900
+        });
+
+        test('capture parameters are integers', () => {
+            const startPoint = { x: 100.7, y: 200.3 };
+            const endPoint = { x: 300.9, y: 450.1 };
+
+            const rect = calculateRect(startPoint, endPoint);
+
+            // For Tauri IPC, we need integers
+            const captureParams = {
+                x: Math.round(rect.x),
+                y: Math.round(rect.y),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height)
+            };
+
+            expect(Number.isInteger(captureParams.x)).toBe(true);
+            expect(Number.isInteger(captureParams.y)).toBe(true);
+            expect(Number.isInteger(captureParams.width)).toBe(true);
+            expect(Number.isInteger(captureParams.height)).toBe(true);
+        });
+
+    });
+
+    describe('Selection Validation', () => {
+
+        test('selection below minimum size is rejected', () => {
+            const rect = { x: 100, y: 100, width: 5, height: 5 };
+            const isValid = rect.width >= MIN_SELECTION_SIZE && rect.height >= MIN_SELECTION_SIZE;
+
+            expect(isValid).toBe(false);
+        });
+
+        test('selection at exact minimum size is accepted', () => {
+            const rect = { x: 100, y: 100, width: 10, height: 10 };
+            const isValid = rect.width >= MIN_SELECTION_SIZE && rect.height >= MIN_SELECTION_SIZE;
+
+            expect(isValid).toBe(true);
+        });
+
+        test('click without drag produces invalid selection', () => {
+            const startPoint = { x: 100, y: 100 };
+            const endPoint = { x: 101, y: 101 }; // Very small movement
+
+            const rect = calculateRect(startPoint, endPoint);
+
+            // This should be treated as a click, not a selection
+            const isClick = rect.width < 2 && rect.height < 2;
+            expect(isClick).toBe(true);
+        });
+
+    });
+
+    describe('Multi-Monitor Scenarios', () => {
+
+        test('selection on secondary monitor calculates correctly', () => {
+            // Secondary monitor starts at x=1920
+            const startPoint = { x: 2000, y: 100 };
+            const endPoint = { x: 2400, y: 400 };
+
+            const rect = calculateRect(startPoint, endPoint);
+
+            expect(rect.x).toBe(2000);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(400);
+            expect(rect.height).toBe(300);
+        });
+
+        test('selection spanning monitors is calculated correctly', () => {
+            // Selection from primary to secondary monitor
+            const startPoint = { x: 1800, y: 500 };
+            const endPoint = { x: 2200, y: 700 };
+
+            const rect = calculateRect(startPoint, endPoint);
+
+            expect(rect.x).toBe(1800);
+            expect(rect.width).toBe(400);
+            // Spans across monitor boundary at x=1920
+        });
+
+    });
+
+    describe('Capture Result Handling', () => {
+
+        test('capture result contains required fields', () => {
+            expect(mockCaptureResult).toHaveProperty('file_path');
+            expect(mockCaptureResult).toHaveProperty('width');
+            expect(mockCaptureResult).toHaveProperty('height');
+            expect(mockCaptureResult).toHaveProperty('timestamp');
+        });
+
+        test('file path is non-empty string', () => {
+            expect(typeof mockCaptureResult.file_path).toBe('string');
+            expect(mockCaptureResult.file_path.length).toBeGreaterThan(0);
+        });
+
+        test('dimensions are positive integers', () => {
+            expect(mockCaptureResult.width).toBeGreaterThan(0);
+            expect(mockCaptureResult.height).toBeGreaterThan(0);
+            expect(Number.isInteger(mockCaptureResult.width)).toBe(true);
+            expect(Number.isInteger(mockCaptureResult.height)).toBe(true);
+        });
+
+        test('timestamp is in expected format', () => {
+            // Format: YYYY-MM-DD HH:MM:SS
+            const timestampRegex = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+            expect(mockCaptureResult.timestamp).toMatch(timestampRegex);
+        });
+
+    });
+
+    describe('Error Scenarios', () => {
+
+        test('handles capture failure gracefully', async () => {
+            window.__TAURI__.invoke.mockRejectedValue(new Error('Capture failed'));
+
+            // In real app, this would show error toast
+            let errorCaught = false;
+            try {
+                await window.__TAURI__.invoke('capture_screen_region', {
+                    x: 0, y: 0, width: 100, height: 100
+                });
+            } catch (e) {
+                errorCaught = true;
+                expect(e.message).toBe('Capture failed');
+            }
+            expect(errorCaught).toBe(true);
+        });
+
+        test('handles selection too small error', async () => {
+            window.__TAURI__.invoke.mockRejectedValue(
+                new Error('Selection too small (minimum 10x10px)')
+            );
+
+            let errorMessage = '';
+            try {
+                await window.__TAURI__.invoke('capture_screen_region', {
+                    x: 0, y: 0, width: 5, height: 5
+                });
+            } catch (e) {
+                errorMessage = e.message;
+            }
+            expect(errorMessage).toContain('10x10');
+        });
+
+    });
+
+    describe('State Management', () => {
+
+        test('state has correct structure for capture workflow', () => {
+            expect(state).toHaveProperty('isSelecting');
+            expect(state).toHaveProperty('isDragging');
+            expect(state).toHaveProperty('startPoint');
+            expect(state).toHaveProperty('currentPoint');
+            expect(state).toHaveProperty('selectionRect');
+        });
+
+        test('initial state is ready for selection', () => {
+            // After reset, should be ready for new selection
+            expect(typeof state.isSelecting).toBe('boolean');
+            expect(typeof state.isDragging).toBe('boolean');
+        });
+
+    });
+
+});
+
+describe('Performance Considerations', () => {
+
+    test('rectangle calculation is fast', () => {
+        const start = performance.now();
+
+        // Perform 10000 calculations
+        for (let i = 0; i < 10000; i++) {
+            calculateRect({ x: i, y: i }, { x: i + 100, y: i + 100 });
+        }
+
+        const elapsed = performance.now() - start;
+        // Should complete in under 100ms
+        expect(elapsed).toBeLessThan(100);
+    });
+
+    test('clamping is fast', () => {
+        const start = performance.now();
+
+        // Perform 10000 clamps
+        for (let i = 0; i < 10000; i++) {
+            clampToScreen({ x: i, y: i, width: 100, height: 100 });
+        }
+
+        const elapsed = performance.now() - start;
+        // Should complete in under 100ms
+        expect(elapsed).toBeLessThan(100);
+    });
+
+});

--- a/wrapper/src/tests/edge_cases.test.js
+++ b/wrapper/src/tests/edge_cases.test.js
@@ -14,6 +14,8 @@ const {
     ErrorType
 } = require('../overlay.js');
 
+const { resetOverlayState } = require('./test-helpers.js');
+
 describe('Selection Validation', () => {
 
     describe('isSelectionValid', () => {
@@ -255,14 +257,7 @@ describe('Selection Calculation Edge Cases', () => {
 describe('State Management Edge Cases', () => {
 
     beforeEach(() => {
-        // Reset state
-        state.isSelecting = false;
-        state.isDragging = false;
-        state.startPoint = null;
-        state.currentPoint = null;
-        state.selectionRect = null;
-        state.permissionChecked = false;
-        state.hasPermission = true;
+        resetOverlayState();
     });
 
     test('state has permission tracking properties', () => {

--- a/wrapper/src/tests/edge_cases.test.js
+++ b/wrapper/src/tests/edge_cases.test.js
@@ -1,0 +1,346 @@
+/**
+ * Edge Case Tests
+ * Tests for validation, error handling, and boundary conditions
+ */
+
+const {
+    calculateRect,
+    clampToScreen,
+    isSelectionValid,
+    isJustAClick,
+    parseErrorMessage,
+    state,
+    MIN_SELECTION_SIZE,
+    ErrorType
+} = require('../overlay.js');
+
+describe('Selection Validation', () => {
+
+    describe('isSelectionValid', () => {
+
+        test('returns false for null rect', () => {
+            expect(isSelectionValid(null)).toBe(false);
+        });
+
+        test('returns false for undefined rect', () => {
+            expect(isSelectionValid(undefined)).toBe(false);
+        });
+
+        test('returns false for rect smaller than minimum', () => {
+            expect(isSelectionValid({ x: 0, y: 0, width: 5, height: 5 })).toBe(false);
+            expect(isSelectionValid({ x: 0, y: 0, width: 9, height: 9 })).toBe(false);
+        });
+
+        test('returns false when only width is too small', () => {
+            expect(isSelectionValid({ x: 0, y: 0, width: 5, height: 100 })).toBe(false);
+        });
+
+        test('returns false when only height is too small', () => {
+            expect(isSelectionValid({ x: 0, y: 0, width: 100, height: 5 })).toBe(false);
+        });
+
+        test('returns true for rect at exact minimum size', () => {
+            expect(isSelectionValid({
+                x: 0, y: 0,
+                width: MIN_SELECTION_SIZE,
+                height: MIN_SELECTION_SIZE
+            })).toBe(true);
+        });
+
+        test('returns true for rect larger than minimum', () => {
+            expect(isSelectionValid({ x: 0, y: 0, width: 100, height: 100 })).toBe(true);
+            expect(isSelectionValid({ x: 0, y: 0, width: 1000, height: 500 })).toBe(true);
+        });
+
+        test('returns false for zero dimensions', () => {
+            expect(isSelectionValid({ x: 0, y: 0, width: 0, height: 0 })).toBe(false);
+            expect(isSelectionValid({ x: 0, y: 0, width: 0, height: 100 })).toBe(false);
+            expect(isSelectionValid({ x: 0, y: 0, width: 100, height: 0 })).toBe(false);
+        });
+
+    });
+
+    describe('isJustAClick', () => {
+
+        test('returns true for null rect', () => {
+            expect(isJustAClick(null)).toBe(true);
+        });
+
+        test('returns true for undefined rect', () => {
+            expect(isJustAClick(undefined)).toBe(true);
+        });
+
+        test('returns true for very small movement (less than 2px)', () => {
+            expect(isJustAClick({ x: 0, y: 0, width: 0, height: 0 })).toBe(true);
+            expect(isJustAClick({ x: 0, y: 0, width: 1, height: 1 })).toBe(true);
+        });
+
+        test('returns false for movement of 2px or more', () => {
+            expect(isJustAClick({ x: 0, y: 0, width: 2, height: 2 })).toBe(false);
+            expect(isJustAClick({ x: 0, y: 0, width: 5, height: 5 })).toBe(false);
+        });
+
+        test('detects click even with large position', () => {
+            expect(isJustAClick({ x: 1000, y: 1000, width: 1, height: 1 })).toBe(true);
+        });
+
+    });
+
+});
+
+describe('Error Message Parsing', () => {
+
+    describe('parseErrorMessage', () => {
+
+        test('identifies permission denied errors', () => {
+            const result = parseErrorMessage('Permission denied');
+            expect(result.type).toBe(ErrorType.PERMISSION_DENIED);
+            expect(result.message).toContain('permission');
+        });
+
+        test('identifies permission errors with different casing', () => {
+            const result = parseErrorMessage('PERMISSION DENIED: Access not granted');
+            expect(result.type).toBe(ErrorType.PERMISSION_DENIED);
+        });
+
+        test('identifies selection too small errors', () => {
+            const result = parseErrorMessage('Selection too small');
+            expect(result.type).toBe(ErrorType.SELECTION_TOO_SMALL);
+            expect(result.message).toContain(MIN_SELECTION_SIZE.toString());
+        });
+
+        test('identifies minimum size errors', () => {
+            const result = parseErrorMessage('Minimum size not met');
+            expect(result.type).toBe(ErrorType.SELECTION_TOO_SMALL);
+        });
+
+        test('identifies save/file errors', () => {
+            const result1 = parseErrorMessage('Failed to save file');
+            expect(result1.type).toBe(ErrorType.SAVE_FAILED);
+
+            const result2 = parseErrorMessage('File write error');
+            expect(result2.type).toBe(ErrorType.SAVE_FAILED);
+        });
+
+        test('returns capture failed for unknown errors', () => {
+            const result = parseErrorMessage('Unknown error occurred');
+            expect(result.type).toBe(ErrorType.CAPTURE_FAILED);
+            expect(result.message).toContain('try again');
+        });
+
+        test('handles Error objects', () => {
+            const result = parseErrorMessage(new Error('Permission denied'));
+            expect(result.type).toBe(ErrorType.PERMISSION_DENIED);
+        });
+
+        test('provides user-friendly messages', () => {
+            const result = parseErrorMessage('permission');
+            expect(result.message.length).toBeGreaterThan(10);
+            expect(result.message).not.toContain('undefined');
+        });
+
+    });
+
+});
+
+describe('ErrorType Constants', () => {
+
+    test('has all required error types', () => {
+        expect(ErrorType.SELECTION_TOO_SMALL).toBeDefined();
+        expect(ErrorType.PERMISSION_DENIED).toBeDefined();
+        expect(ErrorType.CAPTURE_FAILED).toBeDefined();
+        expect(ErrorType.SAVE_FAILED).toBeDefined();
+        expect(ErrorType.UNKNOWN).toBeDefined();
+    });
+
+    test('error types are unique strings', () => {
+        const types = Object.values(ErrorType);
+        const uniqueTypes = new Set(types);
+        expect(uniqueTypes.size).toBe(types.length);
+    });
+
+});
+
+describe('Screen Boundary Handling', () => {
+
+    describe('clampToScreen edge cases', () => {
+
+        test('clamps rect completely outside screen (far negative)', () => {
+            const rect = { x: -500, y: -500, width: 100, height: 100 };
+            const clamped = clampToScreen(rect);
+            expect(clamped.x).toBe(0);
+            expect(clamped.y).toBe(0);
+            expect(clamped.width).toBe(0);
+            expect(clamped.height).toBe(0);
+        });
+
+        test('handles rect at exact screen boundaries', () => {
+            const rect = { x: 0, y: 0, width: 1920, height: 1080 };
+            const clamped = clampToScreen(rect);
+            expect(clamped.x).toBe(0);
+            expect(clamped.y).toBe(0);
+        });
+
+        test('handles very large selections', () => {
+            const rect = { x: 0, y: 0, width: 10000, height: 10000 };
+            const clamped = clampToScreen(rect);
+            expect(clamped.width).toBeLessThanOrEqual(window.innerWidth);
+            expect(clamped.height).toBeLessThanOrEqual(window.innerHeight);
+        });
+
+        test('maintains position when only size exceeds bounds', () => {
+            const rect = { x: 100, y: 100, width: 5000, height: 5000 };
+            const clamped = clampToScreen(rect);
+            expect(clamped.x).toBe(100);
+            expect(clamped.y).toBe(100);
+        });
+
+    });
+
+});
+
+describe('Selection Calculation Edge Cases', () => {
+
+    describe('calculateRect edge cases', () => {
+
+        test('handles floating point coordinates', () => {
+            const rect = calculateRect(
+                { x: 100.7, y: 200.3 },
+                { x: 300.9, y: 450.1 }
+            );
+            expect(rect.x).toBeCloseTo(100.7, 1);
+            expect(rect.y).toBeCloseTo(200.3, 1);
+        });
+
+        test('handles very large coordinates', () => {
+            const rect = calculateRect(
+                { x: 10000, y: 10000 },
+                { x: 20000, y: 20000 }
+            );
+            expect(rect.width).toBe(10000);
+            expect(rect.height).toBe(10000);
+        });
+
+        test('handles negative coordinates', () => {
+            const rect = calculateRect(
+                { x: -100, y: -100 },
+                { x: 100, y: 100 }
+            );
+            expect(rect.x).toBe(-100);
+            expect(rect.y).toBe(-100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(200);
+        });
+
+        test('handles diagonal drag from any corner', () => {
+            // All four corners should produce same size rect
+            const corners = [
+                [{ x: 0, y: 0 }, { x: 100, y: 100 }],
+                [{ x: 100, y: 0 }, { x: 0, y: 100 }],
+                [{ x: 0, y: 100 }, { x: 100, y: 0 }],
+                [{ x: 100, y: 100 }, { x: 0, y: 0 }]
+            ];
+
+            corners.forEach(([p1, p2]) => {
+                const rect = calculateRect(p1, p2);
+                expect(rect.width).toBe(100);
+                expect(rect.height).toBe(100);
+            });
+        });
+
+    });
+
+});
+
+describe('State Management Edge Cases', () => {
+
+    beforeEach(() => {
+        // Reset state
+        state.isSelecting = false;
+        state.isDragging = false;
+        state.startPoint = null;
+        state.currentPoint = null;
+        state.selectionRect = null;
+        state.permissionChecked = false;
+        state.hasPermission = true;
+    });
+
+    test('state has permission tracking properties', () => {
+        expect(state).toHaveProperty('permissionChecked');
+        expect(state).toHaveProperty('hasPermission');
+    });
+
+    test('initial permission state is true (optimistic)', () => {
+        expect(state.hasPermission).toBe(true);
+    });
+
+    test('permission can be set to false', () => {
+        state.hasPermission = false;
+        expect(state.hasPermission).toBe(false);
+    });
+
+    test('permissionChecked can be toggled', () => {
+        expect(state.permissionChecked).toBe(false);
+        state.permissionChecked = true;
+        expect(state.permissionChecked).toBe(true);
+    });
+
+});
+
+describe('Multi-Monitor Considerations', () => {
+
+    test('selection on secondary monitor coordinates', () => {
+        // Simulate secondary monitor starting at x=1920
+        const rect = calculateRect(
+            { x: 2000, y: 100 },
+            { x: 2400, y: 400 }
+        );
+        expect(rect.x).toBe(2000);
+        expect(rect.width).toBe(400);
+        expect(rect.height).toBe(300);
+    });
+
+    test('selection spanning monitor boundary', () => {
+        // Selection from primary (ending at 1920) to secondary
+        const rect = calculateRect(
+            { x: 1800, y: 500 },
+            { x: 2100, y: 700 }
+        );
+        expect(rect.x).toBe(1800);
+        expect(rect.width).toBe(300);
+        // Would span from x=1800 to x=2100
+    });
+
+    test('selection on monitor with negative coordinates', () => {
+        // Some multi-monitor setups have negative coordinates
+        const rect = calculateRect(
+            { x: -1920, y: 0 },
+            { x: -1720, y: 200 }
+        );
+        expect(rect.x).toBe(-1920);
+        expect(rect.width).toBe(200);
+    });
+
+});
+
+describe('Input Sanitization', () => {
+
+    test('calculateRect handles object with extra properties', () => {
+        const rect = calculateRect(
+            { x: 100, y: 100, z: 999, extra: 'ignored' },
+            { x: 200, y: 200, other: true }
+        );
+        expect(rect.x).toBe(100);
+        expect(rect.width).toBe(100);
+    });
+
+    test('isSelectionValid handles rect with extra properties', () => {
+        const valid = isSelectionValid({
+            x: 0, y: 0,
+            width: 100, height: 100,
+            extra: 'data'
+        });
+        expect(valid).toBe(true);
+    });
+
+});

--- a/wrapper/src/tests/final_integration.test.js
+++ b/wrapper/src/tests/final_integration.test.js
@@ -1,0 +1,350 @@
+/**
+ * Final Integration Tests
+ * Comprehensive tests verifying the complete capture workflow
+ */
+
+const overlay = require('../overlay.js');
+const preview = require('../preview.js');
+
+describe('Complete Capture Workflow', () => {
+
+    beforeEach(() => {
+        // Reset overlay state
+        overlay.state.isSelecting = false;
+        overlay.state.isDragging = false;
+        overlay.state.startPoint = null;
+        overlay.state.currentPoint = null;
+        overlay.state.selectionRect = null;
+        overlay.state.permissionChecked = false;
+        overlay.state.hasPermission = true;
+
+        // Reset preview state
+        preview.state.zoom = preview.DEFAULT_ZOOM;
+        preview.state.imagePath = null;
+        preview.state.isPanning = false;
+    });
+
+    describe('Selection to Capture Flow', () => {
+
+        test('complete flow: mouse down -> drag -> mouse up -> valid selection', () => {
+            // Simulate mouse down
+            overlay.state.isSelecting = true;
+            overlay.state.isDragging = true;
+            overlay.state.startPoint = { x: 100, y: 100 };
+
+            // Simulate drag
+            overlay.state.currentPoint = { x: 400, y: 350 };
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+            overlay.state.selectionRect = rect;
+
+            // Verify selection is valid
+            expect(overlay.isSelectionValid(rect)).toBe(true);
+            expect(overlay.isJustAClick(rect)).toBe(false);
+
+            // Verify dimensions
+            expect(rect.width).toBe(300);
+            expect(rect.height).toBe(250);
+
+            // Clamp to screen
+            const clamped = overlay.clampToScreen(rect);
+            expect(clamped.width).toBeGreaterThanOrEqual(overlay.MIN_SELECTION_SIZE);
+            expect(clamped.height).toBeGreaterThanOrEqual(overlay.MIN_SELECTION_SIZE);
+        });
+
+        test('complete flow handles minimum valid selection', () => {
+            overlay.state.startPoint = { x: 500, y: 500 };
+            overlay.state.currentPoint = {
+                x: 500 + overlay.MIN_SELECTION_SIZE,
+                y: 500 + overlay.MIN_SELECTION_SIZE
+            };
+
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+
+            expect(overlay.isSelectionValid(rect)).toBe(true);
+            expect(rect.width).toBe(overlay.MIN_SELECTION_SIZE);
+            expect(rect.height).toBe(overlay.MIN_SELECTION_SIZE);
+        });
+
+        test('complete flow rejects click without drag', () => {
+            overlay.state.startPoint = { x: 500, y: 500 };
+            overlay.state.currentPoint = { x: 501, y: 501 };
+
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+
+            expect(overlay.isJustAClick(rect)).toBe(true);
+        });
+
+    });
+
+    describe('Preview Window Flow', () => {
+
+        test('complete flow: load image -> zoom -> pan', () => {
+            // Simulate image loaded
+            preview.state.imagePath = '/tmp/capture_test.png';
+            preview.state.imageWidth = 1920;
+            preview.state.imageHeight = 1080;
+
+            // Verify initial state
+            expect(preview.state.zoom).toBe(preview.DEFAULT_ZOOM);
+
+            // Zoom in
+            preview.zoomIn();
+            expect(preview.state.zoom).toBe(preview.DEFAULT_ZOOM + preview.ZOOM_STEP);
+
+            // Zoom out
+            preview.zoomOut();
+            expect(preview.state.zoom).toBe(preview.DEFAULT_ZOOM);
+
+            // Set specific zoom
+            preview.setZoom(2.0);
+            expect(preview.state.zoom).toBe(2.0);
+        });
+
+        test('complete flow: file path conversion for different platforms', () => {
+            // Unix path
+            const unixPath = '/Users/test/captures/screenshot.png';
+            const unixUrl = preview.convertFilePath(unixPath);
+            expect(unixUrl).toContain('file://');
+
+            // Windows path
+            const winPath = 'C:\\Users\\test\\captures\\screenshot.png';
+            const winUrl = preview.convertFilePath(winPath);
+            expect(winUrl).toContain('file:///');
+            expect(winUrl).not.toContain('\\');
+        });
+
+    });
+
+    describe('Error Handling Flow', () => {
+
+        test('complete flow: permission denied scenario', () => {
+            overlay.state.hasPermission = false;
+
+            // Attempt to capture should be blocked by permission check
+            expect(overlay.state.hasPermission).toBe(false);
+
+            // Error should be parseable
+            const error = overlay.parseErrorMessage('Permission denied');
+            expect(error.type).toBe(overlay.ErrorType.PERMISSION_DENIED);
+        });
+
+        test('complete flow: selection too small scenario', () => {
+            overlay.state.startPoint = { x: 100, y: 100 };
+            overlay.state.currentPoint = { x: 105, y: 105 };
+
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+
+            expect(overlay.isSelectionValid(rect)).toBe(false);
+
+            const error = overlay.parseErrorMessage('Selection too small');
+            expect(error.type).toBe(overlay.ErrorType.SELECTION_TOO_SMALL);
+            expect(error.message).toContain(overlay.MIN_SELECTION_SIZE.toString());
+        });
+
+    });
+
+    describe('Multi-Monitor Flow', () => {
+
+        test('selection on extended desktop (secondary monitor)', () => {
+            // Secondary monitor starts at x = 1920
+            overlay.state.startPoint = { x: 2000, y: 100 };
+            overlay.state.currentPoint = { x: 2500, y: 400 };
+
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+
+            expect(rect.x).toBe(2000);
+            expect(rect.width).toBe(500);
+            expect(rect.height).toBe(300);
+            expect(overlay.isSelectionValid(rect)).toBe(true);
+        });
+
+        test('selection spanning multiple monitors', () => {
+            // Selection from primary to secondary
+            overlay.state.startPoint = { x: 1800, y: 500 };
+            overlay.state.currentPoint = { x: 2200, y: 800 };
+
+            const rect = overlay.calculateRect(
+                overlay.state.startPoint,
+                overlay.state.currentPoint
+            );
+
+            expect(rect.x).toBe(1800);
+            expect(rect.width).toBe(400);
+            expect(overlay.isSelectionValid(rect)).toBe(true);
+        });
+
+    });
+
+    describe('State Consistency', () => {
+
+        test('overlay and preview states are independent', () => {
+            overlay.state.isSelecting = true;
+            preview.state.isPanning = true;
+
+            expect(overlay.state.isSelecting).toBe(true);
+            expect(preview.state.isPanning).toBe(true);
+            expect(overlay.state).not.toBe(preview.state);
+        });
+
+        test('state modifications are isolated', () => {
+            const overlayStart = { ...overlay.state };
+            const previewStart = { ...preview.state };
+
+            // Modify overlay
+            overlay.state.startPoint = { x: 100, y: 100 };
+
+            // Modify preview
+            preview.state.zoom = 2.5;
+
+            // Verify isolation
+            expect(overlay.state.startPoint).toEqual({ x: 100, y: 100 });
+            expect(preview.state.zoom).toBe(2.5);
+
+            // Reset
+            overlay.state.startPoint = null;
+            preview.state.zoom = preview.DEFAULT_ZOOM;
+        });
+
+    });
+
+});
+
+describe('API Contract Verification', () => {
+
+    describe('Overlay Module Exports', () => {
+
+        test('exports all required functions', () => {
+            expect(typeof overlay.calculateRect).toBe('function');
+            expect(typeof overlay.clampToScreen).toBe('function');
+            expect(typeof overlay.isSelectionValid).toBe('function');
+            expect(typeof overlay.isJustAClick).toBe('function');
+            expect(typeof overlay.parseErrorMessage).toBe('function');
+        });
+
+        test('exports all required constants', () => {
+            expect(overlay.MIN_SELECTION_SIZE).toBeDefined();
+            expect(typeof overlay.MIN_SELECTION_SIZE).toBe('number');
+            expect(overlay.MIN_SELECTION_SIZE).toBe(10);
+        });
+
+        test('exports ErrorType enum', () => {
+            expect(overlay.ErrorType).toBeDefined();
+            expect(overlay.ErrorType.SELECTION_TOO_SMALL).toBeDefined();
+            expect(overlay.ErrorType.PERMISSION_DENIED).toBeDefined();
+            expect(overlay.ErrorType.CAPTURE_FAILED).toBeDefined();
+            expect(overlay.ErrorType.SAVE_FAILED).toBeDefined();
+        });
+
+        test('exports state object', () => {
+            expect(overlay.state).toBeDefined();
+            expect(typeof overlay.state).toBe('object');
+        });
+
+    });
+
+    describe('Preview Module Exports', () => {
+
+        test('exports all required functions', () => {
+            expect(typeof preview.formatFileSize).toBe('function');
+            expect(typeof preview.setZoom).toBe('function');
+            expect(typeof preview.zoomIn).toBe('function');
+            expect(typeof preview.zoomOut).toBe('function');
+            expect(typeof preview.convertFilePath).toBe('function');
+        });
+
+        test('exports all required constants', () => {
+            expect(preview.MIN_ZOOM).toBeDefined();
+            expect(preview.MAX_ZOOM).toBeDefined();
+            expect(preview.ZOOM_STEP).toBeDefined();
+            expect(preview.DEFAULT_ZOOM).toBeDefined();
+        });
+
+        test('exports state object', () => {
+            expect(preview.state).toBeDefined();
+            expect(typeof preview.state).toBe('object');
+        });
+
+    });
+
+});
+
+describe('Cross-Module Integration', () => {
+
+    test('overlay selection parameters are compatible with capture command format', () => {
+        const selection = overlay.calculateRect(
+            { x: 100.5, y: 200.7 },
+            { x: 400.9, y: 500.3 }
+        );
+
+        // Capture command expects integers
+        const captureParams = {
+            x: Math.round(selection.x),
+            y: Math.round(selection.y),
+            width: Math.round(selection.width),
+            height: Math.round(selection.height)
+        };
+
+        expect(Number.isInteger(captureParams.x)).toBe(true);
+        expect(Number.isInteger(captureParams.y)).toBe(true);
+        expect(Number.isInteger(captureParams.width)).toBe(true);
+        expect(Number.isInteger(captureParams.height)).toBe(true);
+    });
+
+    test('file paths from capture are valid for preview', () => {
+        // Simulate capture result
+        const captureResult = {
+            file_path: '/tmp/capture_20231118_120000_abc123.png',
+            width: 300,
+            height: 250,
+            timestamp: '2023-11-18 12:00:00'
+        };
+
+        // Convert for preview
+        const previewUrl = preview.convertFilePath(captureResult.file_path);
+        expect(previewUrl).toContain('file://');
+        expect(previewUrl).toContain('capture_20231118_120000_abc123.png');
+    });
+
+});
+
+describe('Requirements Verification', () => {
+
+    test('minimum selection size is 10x10 pixels', () => {
+        expect(overlay.MIN_SELECTION_SIZE).toBe(10);
+
+        // 9x9 is invalid
+        expect(overlay.isSelectionValid({ x: 0, y: 0, width: 9, height: 9 })).toBe(false);
+
+        // 10x10 is valid
+        expect(overlay.isSelectionValid({ x: 0, y: 0, width: 10, height: 10 })).toBe(true);
+    });
+
+    test('zoom range is 10% to 500%', () => {
+        expect(preview.MIN_ZOOM).toBe(0.1);
+        expect(preview.MAX_ZOOM).toBe(5.0);
+    });
+
+    test('default zoom is 100%', () => {
+        expect(preview.DEFAULT_ZOOM).toBe(1.0);
+    });
+
+    test('zoom step is 25%', () => {
+        expect(preview.ZOOM_STEP).toBe(0.25);
+    });
+
+});

--- a/wrapper/src/tests/final_integration.test.js
+++ b/wrapper/src/tests/final_integration.test.js
@@ -3,25 +3,17 @@
  * Comprehensive tests verifying the complete capture workflow
  */
 
-const overlay = require('../overlay.js');
-const preview = require('../preview.js');
+const {
+    overlay,
+    preview,
+    resetAllStates,
+    simulateMouseDrag
+} = require('./test-helpers.js');
 
 describe('Complete Capture Workflow', () => {
 
     beforeEach(() => {
-        // Reset overlay state
-        overlay.state.isSelecting = false;
-        overlay.state.isDragging = false;
-        overlay.state.startPoint = null;
-        overlay.state.currentPoint = null;
-        overlay.state.selectionRect = null;
-        overlay.state.permissionChecked = false;
-        overlay.state.hasPermission = true;
-
-        // Reset preview state
-        preview.state.zoom = preview.DEFAULT_ZOOM;
-        preview.state.imagePath = null;
-        preview.state.isPanning = false;
+        resetAllStates();
     });
 
     describe('Selection to Capture Flow', () => {

--- a/wrapper/src/tests/overlay.test.js
+++ b/wrapper/src/tests/overlay.test.js
@@ -1,0 +1,308 @@
+/**
+ * Unit Tests for Screen Capture Overlay
+ * Tests the core selection logic and coordinate calculations
+ *
+ * Note: setup.js runs before this file to configure the DOM environment
+ */
+
+// Import the overlay module functions
+const {
+    calculateRect,
+    clampToScreen,
+    state,
+    MIN_SELECTION_SIZE
+} = require('../overlay.js');
+
+describe('Overlay Selection Logic', () => {
+
+    // ==================== Rectangle Calculation Tests ====================
+
+    describe('calculateRect', () => {
+
+        test('calculates rectangle from top-left to bottom-right drag', () => {
+            const point1 = { x: 100, y: 100 };
+            const point2 = { x: 300, y: 250 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(100);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(150);
+        });
+
+        test('calculates rectangle from bottom-right to top-left drag', () => {
+            const point1 = { x: 300, y: 250 };
+            const point2 = { x: 100, y: 100 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(100);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(150);
+        });
+
+        test('calculates rectangle from top-right to bottom-left drag', () => {
+            const point1 = { x: 300, y: 100 };
+            const point2 = { x: 100, y: 250 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(100);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(150);
+        });
+
+        test('calculates rectangle from bottom-left to top-right drag', () => {
+            const point1 = { x: 100, y: 250 };
+            const point2 = { x: 300, y: 100 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(100);
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(200);
+            expect(rect.height).toBe(150);
+        });
+
+        test('handles zero-width rectangle', () => {
+            const point1 = { x: 100, y: 100 };
+            const point2 = { x: 100, y: 200 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(100);
+            expect(rect.width).toBe(0);
+            expect(rect.height).toBe(100);
+        });
+
+        test('handles zero-height rectangle', () => {
+            const point1 = { x: 100, y: 100 };
+            const point2 = { x: 200, y: 100 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.y).toBe(100);
+            expect(rect.width).toBe(100);
+            expect(rect.height).toBe(0);
+        });
+
+        test('returns null for null point1', () => {
+            const rect = calculateRect(null, { x: 100, y: 100 });
+            expect(rect).toBeNull();
+        });
+
+        test('returns null for null point2', () => {
+            const rect = calculateRect({ x: 100, y: 100 }, null);
+            expect(rect).toBeNull();
+        });
+
+        test('handles negative coordinates', () => {
+            const point1 = { x: -50, y: -30 };
+            const point2 = { x: 50, y: 70 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(-50);
+            expect(rect.y).toBe(-30);
+            expect(rect.width).toBe(100);
+            expect(rect.height).toBe(100);
+        });
+
+        test('handles same point (click without drag)', () => {
+            const point1 = { x: 150, y: 150 };
+            const point2 = { x: 150, y: 150 };
+            const rect = calculateRect(point1, point2);
+
+            expect(rect.x).toBe(150);
+            expect(rect.y).toBe(150);
+            expect(rect.width).toBe(0);
+            expect(rect.height).toBe(0);
+        });
+
+    });
+
+    // ==================== Boundary Clamping Tests ====================
+
+    describe('clampToScreen', () => {
+
+        beforeEach(() => {
+            // Reset window dimensions for consistent testing
+            global.window.innerWidth = 1920;
+            global.window.innerHeight = 1080;
+        });
+
+        test('does not modify rect fully within screen', () => {
+            const rect = { x: 100, y: 100, width: 200, height: 150 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.x).toBe(100);
+            expect(clamped.y).toBe(100);
+            expect(clamped.width).toBe(200);
+            expect(clamped.height).toBe(150);
+        });
+
+        test('clamps negative x to 0', () => {
+            const rect = { x: -50, y: 100, width: 200, height: 150 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.x).toBe(0);
+            expect(clamped.width).toBe(150); // 200 - 50 = 150
+        });
+
+        test('clamps negative y to 0', () => {
+            const rect = { x: 100, y: -30, width: 200, height: 150 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.y).toBe(0);
+            expect(clamped.height).toBe(120); // 150 - 30 = 120
+        });
+
+        test('clamps width extending past right edge', () => {
+            const rect = { x: 1800, y: 100, width: 200, height: 150 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.x).toBe(1800);
+            expect(clamped.width).toBe(120); // 1920 - 1800 = 120
+        });
+
+        test('clamps height extending past bottom edge', () => {
+            const rect = { x: 100, y: 1000, width: 200, height: 150 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.y).toBe(1000);
+            expect(clamped.height).toBe(80); // 1080 - 1000 = 80
+        });
+
+        test('handles rect completely outside screen (negative)', () => {
+            const rect = { x: -300, y: -200, width: 100, height: 100 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.x).toBe(0);
+            expect(clamped.y).toBe(0);
+            expect(clamped.width).toBe(0); // Fully outside
+            expect(clamped.height).toBe(0);
+        });
+
+        test('handles rect at exact screen boundaries', () => {
+            const rect = { x: 0, y: 0, width: 1920, height: 1080 };
+            const clamped = clampToScreen(rect);
+
+            expect(clamped.x).toBe(0);
+            expect(clamped.y).toBe(0);
+            expect(clamped.width).toBe(1920);
+            expect(clamped.height).toBe(1080);
+        });
+
+    });
+
+    // ==================== Minimum Size Constant Tests ====================
+
+    describe('MIN_SELECTION_SIZE', () => {
+
+        test('minimum size is 10 pixels', () => {
+            expect(MIN_SELECTION_SIZE).toBe(10);
+        });
+
+        test('selection at minimum size should be valid', () => {
+            const rect = { x: 0, y: 0, width: 10, height: 10 };
+            const isValid = rect.width >= MIN_SELECTION_SIZE && rect.height >= MIN_SELECTION_SIZE;
+            expect(isValid).toBe(true);
+        });
+
+        test('selection below minimum size should be invalid', () => {
+            const rect = { x: 0, y: 0, width: 9, height: 9 };
+            const isValid = rect.width >= MIN_SELECTION_SIZE && rect.height >= MIN_SELECTION_SIZE;
+            expect(isValid).toBe(false);
+        });
+
+    });
+
+    // ==================== State Management Tests ====================
+
+    describe('state', () => {
+
+        test('initial state has correct default values', () => {
+            // Note: state may have been modified by previous tests
+            // These test the structure, actual values may vary
+            expect(state).toHaveProperty('isSelecting');
+            expect(state).toHaveProperty('isDragging');
+            expect(state).toHaveProperty('startPoint');
+            expect(state).toHaveProperty('currentPoint');
+            expect(state).toHaveProperty('selectionRect');
+            expect(state).toHaveProperty('animationFrameId');
+            expect(state).toHaveProperty('instructionsVisible');
+        });
+
+        test('state properties are correct types', () => {
+            expect(typeof state.isSelecting).toBe('boolean');
+            expect(typeof state.isDragging).toBe('boolean');
+            expect(typeof state.instructionsVisible).toBe('boolean');
+        });
+
+    });
+
+});
+
+// ==================== Integration-style Tests ====================
+
+describe('Selection Workflow', () => {
+
+    test('complete selection workflow produces valid rect', () => {
+        // Simulate a complete drag selection
+        const startPoint = { x: 100, y: 100 };
+        const endPoint = { x: 400, y: 300 };
+
+        const rect = calculateRect(startPoint, endPoint);
+        const clamped = clampToScreen(rect);
+
+        expect(clamped.width).toBeGreaterThanOrEqual(MIN_SELECTION_SIZE);
+        expect(clamped.height).toBeGreaterThanOrEqual(MIN_SELECTION_SIZE);
+        expect(clamped.x).toBeGreaterThanOrEqual(0);
+        expect(clamped.y).toBeGreaterThanOrEqual(0);
+    });
+
+    test('very small drag is detected as click', () => {
+        const startPoint = { x: 100, y: 100 };
+        const endPoint = { x: 101, y: 101 };
+
+        const rect = calculateRect(startPoint, endPoint);
+
+        // This should be treated as a click (width and height < 2)
+        expect(rect.width).toBeLessThan(2);
+        expect(rect.height).toBeLessThan(2);
+    });
+
+    test('selection spanning full screen is valid', () => {
+        const startPoint = { x: 0, y: 0 };
+        const endPoint = { x: 1920, y: 1080 };
+
+        const rect = calculateRect(startPoint, endPoint);
+        const clamped = clampToScreen(rect);
+
+        expect(clamped.width).toBe(1920);
+        expect(clamped.height).toBe(1080);
+    });
+
+});
+
+// ==================== Edge Case Tests ====================
+
+describe('Edge Cases', () => {
+
+    test('floating point coordinates are handled', () => {
+        const point1 = { x: 100.5, y: 100.7 };
+        const point2 = { x: 300.3, y: 250.9 };
+        const rect = calculateRect(point1, point2);
+
+        // Should calculate correctly with floats
+        expect(rect).toBeDefined();
+        expect(rect.width).toBeCloseTo(199.8, 1);
+        expect(rect.height).toBeCloseTo(150.2, 1);
+    });
+
+    test('very large coordinates are handled', () => {
+        const point1 = { x: 10000, y: 10000 };
+        const point2 = { x: 10500, y: 10500 };
+        const rect = calculateRect(point1, point2);
+
+        expect(rect.width).toBe(500);
+        expect(rect.height).toBe(500);
+    });
+
+});

--- a/wrapper/src/tests/performance.test.js
+++ b/wrapper/src/tests/performance.test.js
@@ -1,0 +1,380 @@
+/**
+ * Performance Tests
+ * Tests for ensuring performance targets are met
+ */
+
+const {
+    calculateRect,
+    clampToScreen,
+    isSelectionValid,
+    isJustAClick,
+    parseErrorMessage,
+    state,
+    MIN_SELECTION_SIZE
+} = require('../overlay.js');
+
+const {
+    formatFileSize,
+    setZoom,
+    zoomIn,
+    zoomOut,
+    convertFilePath,
+    state: previewState,
+    DEFAULT_ZOOM
+} = require('../preview.js');
+
+describe('Performance Benchmarks', () => {
+
+    describe('Overlay Operations', () => {
+
+        test('calculateRect completes 10,000 operations in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                calculateRect(
+                    { x: Math.random() * 1920, y: Math.random() * 1080 },
+                    { x: Math.random() * 1920, y: Math.random() * 1080 }
+                );
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('clampToScreen completes 10,000 operations in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                clampToScreen({
+                    x: Math.random() * 2000 - 100,
+                    y: Math.random() * 1200 - 100,
+                    width: Math.random() * 500,
+                    height: Math.random() * 500
+                });
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('isSelectionValid completes 100,000 operations in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 100000; i++) {
+                isSelectionValid({
+                    x: i % 1920,
+                    y: i % 1080,
+                    width: (i % 500) + 1,
+                    height: (i % 500) + 1
+                });
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('isJustAClick completes 100,000 operations in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 100000; i++) {
+                isJustAClick({
+                    x: i % 1920,
+                    y: i % 1080,
+                    width: i % 10,
+                    height: i % 10
+                });
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('combined selection workflow (calc + clamp + validate) under 100ms for 10,000 iterations', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                const rect = calculateRect(
+                    { x: i % 1920, y: i % 1080 },
+                    { x: (i + 100) % 1920, y: (i + 100) % 1080 }
+                );
+                if (rect && !isJustAClick(rect)) {
+                    const clamped = clampToScreen(rect);
+                    isSelectionValid(clamped);
+                }
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(100);
+        });
+
+    });
+
+    describe('Preview Operations', () => {
+
+        beforeEach(() => {
+            previewState.zoom = DEFAULT_ZOOM;
+        });
+
+        test('formatFileSize completes 100,000 operations in under 100ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 100000; i++) {
+                formatFileSize(i * 1024);
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(100);
+        });
+
+        test('setZoom completes 100,000 operations in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 100000; i++) {
+                setZoom((i % 50) / 10);
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('zoomIn/zoomOut cycle completes 10,000 times in under 50ms', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                zoomIn();
+                zoomOut();
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('convertFilePath completes 10,000 operations in under 50ms', () => {
+            const paths = [
+                '/Users/test/capture.png',
+                'C:\\Users\\test\\capture.png',
+                '/var/folders/captures/image.png',
+                'D:/Downloads/screenshot.png'
+            ];
+
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                convertFilePath(paths[i % paths.length]);
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+    });
+
+    describe('Error Handling Performance', () => {
+
+        test('parseErrorMessage completes 10,000 operations in under 50ms', () => {
+            const errors = [
+                'Permission denied',
+                'Selection too small',
+                'File write error',
+                'Unknown error',
+                new Error('Test error')
+            ];
+
+            const start = performance.now();
+
+            for (let i = 0; i < 10000; i++) {
+                parseErrorMessage(errors[i % errors.length]);
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+    });
+
+    describe('State Operations', () => {
+
+        test('state object access is fast (1,000,000 reads in under 50ms)', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 1000000; i++) {
+                const _ = state.isSelecting;
+                const __ = state.isDragging;
+                const ___ = state.startPoint;
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+        });
+
+        test('state object writes are fast (100,000 writes in under 50ms)', () => {
+            const start = performance.now();
+
+            for (let i = 0; i < 100000; i++) {
+                state.startPoint = { x: i, y: i };
+                state.currentPoint = { x: i + 100, y: i + 100 };
+            }
+
+            const elapsed = performance.now() - start;
+            expect(elapsed).toBeLessThan(50);
+
+            // Reset state
+            state.startPoint = null;
+            state.currentPoint = null;
+        });
+
+    });
+
+});
+
+describe('Memory Efficiency', () => {
+
+    test('calculateRect does not accumulate memory (no leaks)', () => {
+        // Run many iterations and check memory doesn't grow excessively
+        const iterations = 100000;
+        const results = [];
+
+        for (let i = 0; i < iterations; i++) {
+            const rect = calculateRect(
+                { x: i, y: i },
+                { x: i + 100, y: i + 100 }
+            );
+            // Only keep last result to prevent intentional accumulation
+            if (i === iterations - 1) {
+                results.push(rect);
+            }
+        }
+
+        expect(results.length).toBe(1);
+        expect(results[0]).toBeDefined();
+    });
+
+    test('clampToScreen returns new object (no mutation)', () => {
+        const original = { x: -50, y: -50, width: 200, height: 200 };
+        const clamped = clampToScreen(original);
+
+        // Original should not be mutated
+        expect(original.x).toBe(-50);
+        expect(original.y).toBe(-50);
+
+        // Clamped should be different object
+        expect(clamped).not.toBe(original);
+        expect(clamped.x).toBe(0);
+        expect(clamped.y).toBe(0);
+    });
+
+});
+
+describe('60 FPS Render Loop Simulation', () => {
+
+    test('single frame calculations complete in under 16ms (60fps budget)', () => {
+        // Simulate what happens in a single render frame
+        const start = performance.now();
+
+        // Typical frame operations:
+        // 1. Calculate rect from mouse position
+        const rect = calculateRect(
+            { x: 100, y: 100 },
+            { x: 500, y: 400 }
+        );
+
+        // 2. Validate selection
+        const valid = isSelectionValid(rect);
+
+        // 3. Check if just a click
+        const click = isJustAClick(rect);
+
+        // 4. Clamp to screen if needed
+        const clamped = clampToScreen(rect);
+
+        const elapsed = performance.now() - start;
+
+        // 16.67ms is the budget for 60fps
+        expect(elapsed).toBeLessThan(16);
+        expect(valid).toBe(true);
+        expect(click).toBe(false);
+        expect(clamped).toBeDefined();
+    });
+
+    test('100 consecutive frames complete in under 1600ms (maintains 60fps)', () => {
+        const start = performance.now();
+
+        for (let frame = 0; frame < 100; frame++) {
+            // Simulate mouse movement each frame
+            const rect = calculateRect(
+                { x: 100, y: 100 },
+                { x: 100 + frame * 5, y: 100 + frame * 4 }
+            );
+
+            if (rect) {
+                isSelectionValid(rect);
+                isJustAClick(rect);
+                clampToScreen(rect);
+            }
+        }
+
+        const elapsed = performance.now() - start;
+
+        // 100 frames at 60fps = 1666ms budget
+        expect(elapsed).toBeLessThan(1600);
+    });
+
+});
+
+describe('Scalability Tests', () => {
+
+    test('handles very large coordinate values', () => {
+        const start = performance.now();
+
+        const rect = calculateRect(
+            { x: Number.MAX_SAFE_INTEGER - 1000, y: Number.MAX_SAFE_INTEGER - 1000 },
+            { x: Number.MAX_SAFE_INTEGER, y: Number.MAX_SAFE_INTEGER }
+        );
+
+        const elapsed = performance.now() - start;
+
+        expect(elapsed).toBeLessThan(1);
+        expect(rect.width).toBe(1000);
+        expect(rect.height).toBe(1000);
+    });
+
+    test('handles rapid state changes', () => {
+        const start = performance.now();
+
+        for (let i = 0; i < 10000; i++) {
+            state.isSelecting = !state.isSelecting;
+            state.isDragging = !state.isDragging;
+        }
+
+        const elapsed = performance.now() - start;
+        expect(elapsed).toBeLessThan(50);
+
+        // Reset
+        state.isSelecting = false;
+        state.isDragging = false;
+    });
+
+});
+
+describe('Concurrent Operations Simulation', () => {
+
+    test('multiple overlay operations can run together efficiently', () => {
+        const start = performance.now();
+
+        // Simulate concurrent-like operations
+        const operations = [];
+
+        for (let i = 0; i < 1000; i++) {
+            operations.push(
+                calculateRect({ x: i, y: i }, { x: i + 100, y: i + 100 }),
+                clampToScreen({ x: i - 50, y: i - 50, width: 200, height: 200 }),
+                isSelectionValid({ x: 0, y: 0, width: i + 10, height: i + 10 })
+            );
+        }
+
+        const elapsed = performance.now() - start;
+        expect(elapsed).toBeLessThan(100);
+        expect(operations.length).toBe(3000);
+    });
+
+});

--- a/wrapper/src/tests/preview.test.js
+++ b/wrapper/src/tests/preview.test.js
@@ -15,18 +15,12 @@ const {
     DEFAULT_ZOOM
 } = require('../preview.js');
 
+const { resetPreviewState } = require('./test-helpers.js');
+
 describe('Preview Window Logic', () => {
 
     beforeEach(() => {
-        // Reset state before each test
-        state.imagePath = null;
-        state.imageWidth = 0;
-        state.imageHeight = 0;
-        state.fileSize = 0;
-        state.zoom = DEFAULT_ZOOM;
-        state.isPanning = false;
-        state.panStart = { x: 0, y: 0 };
-        state.scrollStart = { x: 0, y: 0 };
+        resetPreviewState();
     });
 
     describe('formatFileSize', () => {

--- a/wrapper/src/tests/preview.test.js
+++ b/wrapper/src/tests/preview.test.js
@@ -1,0 +1,369 @@
+/**
+ * Tests for Preview Window Logic
+ */
+
+const {
+    state,
+    formatFileSize,
+    setZoom,
+    zoomIn,
+    zoomOut,
+    convertFilePath,
+    MIN_ZOOM,
+    MAX_ZOOM,
+    ZOOM_STEP,
+    DEFAULT_ZOOM
+} = require('../preview.js');
+
+describe('Preview Window Logic', () => {
+
+    beforeEach(() => {
+        // Reset state before each test
+        state.imagePath = null;
+        state.imageWidth = 0;
+        state.imageHeight = 0;
+        state.fileSize = 0;
+        state.zoom = DEFAULT_ZOOM;
+        state.isPanning = false;
+        state.panStart = { x: 0, y: 0 };
+        state.scrollStart = { x: 0, y: 0 };
+    });
+
+    describe('formatFileSize', () => {
+
+        test('formats 0 bytes', () => {
+            expect(formatFileSize(0)).toBe('0 B');
+        });
+
+        test('formats bytes', () => {
+            expect(formatFileSize(500)).toBe('500 B');
+        });
+
+        test('formats kilobytes', () => {
+            expect(formatFileSize(1024)).toBe('1 KB');
+            expect(formatFileSize(1536)).toBe('1.5 KB');
+        });
+
+        test('formats megabytes', () => {
+            expect(formatFileSize(1048576)).toBe('1 MB');
+            expect(formatFileSize(2621440)).toBe('2.5 MB');
+        });
+
+        test('formats gigabytes', () => {
+            expect(formatFileSize(1073741824)).toBe('1 GB');
+        });
+
+        test('handles decimal precision', () => {
+            expect(formatFileSize(1234)).toBe('1.2 KB');
+            expect(formatFileSize(1567890)).toBe('1.5 MB');
+        });
+
+    });
+
+    describe('Zoom Constants', () => {
+
+        test('MIN_ZOOM is reasonable value', () => {
+            expect(MIN_ZOOM).toBeGreaterThan(0);
+            expect(MIN_ZOOM).toBeLessThan(1);
+        });
+
+        test('MAX_ZOOM is reasonable value', () => {
+            expect(MAX_ZOOM).toBeGreaterThan(1);
+            expect(MAX_ZOOM).toBeLessThanOrEqual(10);
+        });
+
+        test('ZOOM_STEP is reasonable value', () => {
+            expect(ZOOM_STEP).toBeGreaterThan(0);
+            expect(ZOOM_STEP).toBeLessThan(1);
+        });
+
+        test('DEFAULT_ZOOM is 100%', () => {
+            expect(DEFAULT_ZOOM).toBe(1.0);
+        });
+
+    });
+
+    describe('setZoom', () => {
+
+        test('sets zoom to valid value', () => {
+            setZoom(1.5);
+            expect(state.zoom).toBe(1.5);
+        });
+
+        test('clamps zoom to minimum', () => {
+            setZoom(0.01);
+            expect(state.zoom).toBe(MIN_ZOOM);
+        });
+
+        test('clamps zoom to maximum', () => {
+            setZoom(10);
+            expect(state.zoom).toBe(MAX_ZOOM);
+        });
+
+        test('handles exact boundary values', () => {
+            setZoom(MIN_ZOOM);
+            expect(state.zoom).toBe(MIN_ZOOM);
+
+            setZoom(MAX_ZOOM);
+            expect(state.zoom).toBe(MAX_ZOOM);
+        });
+
+        test('handles negative values', () => {
+            setZoom(-1);
+            expect(state.zoom).toBe(MIN_ZOOM);
+        });
+
+    });
+
+    describe('zoomIn', () => {
+
+        test('increases zoom by ZOOM_STEP', () => {
+            state.zoom = 1.0;
+            zoomIn();
+            expect(state.zoom).toBe(1.0 + ZOOM_STEP);
+        });
+
+        test('does not exceed MAX_ZOOM', () => {
+            state.zoom = MAX_ZOOM - 0.1;
+            zoomIn();
+            expect(state.zoom).toBe(MAX_ZOOM);
+        });
+
+        test('multiple zooms increase correctly', () => {
+            state.zoom = 1.0;
+            zoomIn();
+            zoomIn();
+            zoomIn();
+            expect(state.zoom).toBeCloseTo(1.0 + (ZOOM_STEP * 3), 5);
+        });
+
+    });
+
+    describe('zoomOut', () => {
+
+        test('decreases zoom by ZOOM_STEP', () => {
+            state.zoom = 1.0;
+            zoomOut();
+            expect(state.zoom).toBe(1.0 - ZOOM_STEP);
+        });
+
+        test('does not go below MIN_ZOOM', () => {
+            state.zoom = MIN_ZOOM + 0.05;
+            zoomOut();
+            expect(state.zoom).toBe(MIN_ZOOM);
+        });
+
+        test('multiple zooms decrease correctly', () => {
+            state.zoom = 1.0;
+            zoomOut();
+            zoomOut();
+            expect(state.zoom).toBeCloseTo(1.0 - (ZOOM_STEP * 2), 5);
+        });
+
+    });
+
+    describe('convertFilePath', () => {
+
+        test('converts Unix absolute path', () => {
+            const result = convertFilePath('/tmp/capture.png');
+            expect(result).toBe('file:///tmp/capture.png');
+        });
+
+        test('converts Windows path with drive letter', () => {
+            const result = convertFilePath('C:\\Users\\test\\capture.png');
+            expect(result).toBe('file:///C:/Users/test/capture.png');
+        });
+
+        test('converts Windows path with forward slashes', () => {
+            const result = convertFilePath('D:/Downloads/image.png');
+            expect(result).toBe('file:///D:/Downloads/image.png');
+        });
+
+        test('returns already formatted URL unchanged', () => {
+            const result = convertFilePath('file:///path/to/file.png');
+            expect(result).toBe('file:///path/to/file.png');
+        });
+
+        test('handles paths with spaces', () => {
+            const result = convertFilePath('/Users/test/My Documents/capture.png');
+            expect(result).toBe('file:///Users/test/My Documents/capture.png');
+        });
+
+        test('handles lowercase drive letter', () => {
+            const result = convertFilePath('c:\\test\\file.png');
+            expect(result).toBe('file:///c:/test/file.png');
+        });
+
+    });
+
+    describe('State Management', () => {
+
+        test('initial state has correct structure', () => {
+            expect(state).toHaveProperty('imagePath');
+            expect(state).toHaveProperty('imageWidth');
+            expect(state).toHaveProperty('imageHeight');
+            expect(state).toHaveProperty('fileSize');
+            expect(state).toHaveProperty('zoom');
+            expect(state).toHaveProperty('isPanning');
+            expect(state).toHaveProperty('panStart');
+            expect(state).toHaveProperty('scrollStart');
+        });
+
+        test('state has correct initial values', () => {
+            expect(state.imagePath).toBeNull();
+            expect(state.imageWidth).toBe(0);
+            expect(state.imageHeight).toBe(0);
+            expect(state.zoom).toBe(DEFAULT_ZOOM);
+            expect(state.isPanning).toBe(false);
+        });
+
+        test('panStart and scrollStart have x and y', () => {
+            expect(state.panStart).toHaveProperty('x');
+            expect(state.panStart).toHaveProperty('y');
+            expect(state.scrollStart).toHaveProperty('x');
+            expect(state.scrollStart).toHaveProperty('y');
+        });
+
+    });
+
+    describe('Zoom Boundaries', () => {
+
+        test('cannot zoom below 10%', () => {
+            for (let i = 0; i < 20; i++) {
+                zoomOut();
+            }
+            expect(state.zoom).toBe(MIN_ZOOM);
+            expect(state.zoom).toBeGreaterThanOrEqual(0.1);
+        });
+
+        test('cannot zoom above 500%', () => {
+            for (let i = 0; i < 30; i++) {
+                zoomIn();
+            }
+            expect(state.zoom).toBe(MAX_ZOOM);
+            expect(state.zoom).toBeLessThanOrEqual(5.0);
+        });
+
+        test('zoom operations are reversible', () => {
+            const initialZoom = state.zoom;
+            zoomIn();
+            zoomIn();
+            zoomOut();
+            zoomOut();
+            expect(state.zoom).toBeCloseTo(initialZoom, 5);
+        });
+
+    });
+
+});
+
+describe('Preview Window Integration', () => {
+
+    describe('File Path Handling', () => {
+
+        test('handles macOS typical capture path', () => {
+            const path = '/var/folders/xx/captures/capture_20231118_120000.png';
+            const url = convertFilePath(path);
+            expect(url).toMatch(/^file:\/\//);
+            expect(url).toContain('captures');
+        });
+
+        test('handles Windows typical capture path', () => {
+            const path = 'C:\\Users\\User\\AppData\\Local\\Porua\\captures\\capture.png';
+            const url = convertFilePath(path);
+            expect(url).toMatch(/^file:\/\/\//);
+            expect(url).not.toContain('\\');
+        });
+
+        test('handles special characters in path', () => {
+            const path = '/Users/café/captures/screenshot (1).png';
+            const url = convertFilePath(path);
+            expect(url).toBe('file:///Users/café/captures/screenshot (1).png');
+        });
+
+    });
+
+    describe('Zoom Workflow', () => {
+
+        test('zoom to fit then actual size workflow', () => {
+            // Simulate zoom fit
+            setZoom(0.5);
+            expect(state.zoom).toBe(0.5);
+
+            // Then actual size
+            setZoom(DEFAULT_ZOOM);
+            expect(state.zoom).toBe(1.0);
+        });
+
+        test('precise zoom levels', () => {
+            setZoom(0.25);
+            expect(state.zoom).toBe(0.25);
+
+            setZoom(0.5);
+            expect(state.zoom).toBe(0.5);
+
+            setZoom(0.75);
+            expect(state.zoom).toBe(0.75);
+
+            setZoom(1.5);
+            expect(state.zoom).toBe(1.5);
+
+            setZoom(2.0);
+            expect(state.zoom).toBe(2.0);
+        });
+
+    });
+
+    describe('File Size Display Formatting', () => {
+
+        test('typical screenshot sizes format correctly', () => {
+            // Small screenshot ~100KB
+            expect(formatFileSize(102400)).toBe('100 KB');
+
+            // Medium screenshot ~500KB
+            expect(formatFileSize(512000)).toBe('500 KB');
+
+            // Large screenshot ~2MB
+            expect(formatFileSize(2097152)).toBe('2 MB');
+
+            // 4K screenshot ~5MB
+            expect(formatFileSize(5242880)).toBe('5 MB');
+        });
+
+    });
+
+});
+
+describe('Edge Cases', () => {
+
+    test('rapid zoom in/out maintains bounds', () => {
+        // Rapidly zoom in
+        for (let i = 0; i < 100; i++) {
+            zoomIn();
+        }
+        expect(state.zoom).toBeLessThanOrEqual(MAX_ZOOM);
+
+        // Rapidly zoom out
+        for (let i = 0; i < 100; i++) {
+            zoomOut();
+        }
+        expect(state.zoom).toBeGreaterThanOrEqual(MIN_ZOOM);
+    });
+
+    test('formatFileSize handles edge cases', () => {
+        expect(formatFileSize(1)).toBe('1 B');
+        expect(formatFileSize(1023)).toBe('1023 B');
+        expect(formatFileSize(1025)).toBe('1 KB');
+    });
+
+    test('state properties are mutable', () => {
+        state.imagePath = '/test/path.png';
+        expect(state.imagePath).toBe('/test/path.png');
+
+        state.imageWidth = 1920;
+        state.imageHeight = 1080;
+        expect(state.imageWidth).toBe(1920);
+        expect(state.imageHeight).toBe(1080);
+    });
+
+});

--- a/wrapper/src/tests/setup.js
+++ b/wrapper/src/tests/setup.js
@@ -1,0 +1,17 @@
+/**
+ * Jest Setup File
+ * Configures the test environment before tests run
+ */
+
+// Set window dimensions for tests
+Object.defineProperty(window, 'innerWidth', { value: 1920, writable: true, configurable: true });
+Object.defineProperty(window, 'innerHeight', { value: 1080, writable: true, configurable: true });
+
+// Mock Tauri API
+window.__TAURI__ = {
+    invoke: jest.fn().mockResolvedValue({})
+};
+
+// Mock requestAnimationFrame
+window.requestAnimationFrame = jest.fn((cb) => setTimeout(cb, 16));
+window.cancelAnimationFrame = jest.fn((id) => clearTimeout(id));

--- a/wrapper/src/tests/shortcuts.test.js
+++ b/wrapper/src/tests/shortcuts.test.js
@@ -1,0 +1,293 @@
+/**
+ * Tests for Keyboard Shortcuts and Integration
+ * Tests the keyboard shortcut handling across overlay and preview windows
+ */
+
+// Import overlay and preview modules
+const overlay = require('../overlay.js');
+const preview = require('../preview.js');
+
+describe('Overlay Keyboard Shortcuts', () => {
+
+    beforeEach(() => {
+        // Reset overlay state
+        overlay.state.isSelecting = false;
+        overlay.state.isDragging = false;
+        overlay.state.startPoint = null;
+        overlay.state.currentPoint = null;
+        overlay.state.selectionRect = null;
+    });
+
+    describe('Escape Key Handling', () => {
+
+        test('Escape key should be recognized for cancel', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape' });
+            expect(event.key).toBe('Escape');
+        });
+
+        test('Escape key code is correct', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape' });
+            expect(event.code).toBe('Escape');
+        });
+
+    });
+
+    describe('Selection State', () => {
+
+        test('state can track selection mode', () => {
+            overlay.state.isSelecting = true;
+            expect(overlay.state.isSelecting).toBe(true);
+        });
+
+        test('state can track dragging', () => {
+            overlay.state.isDragging = true;
+            expect(overlay.state.isDragging).toBe(true);
+        });
+
+        test('selection points can be set', () => {
+            overlay.state.startPoint = { x: 100, y: 100 };
+            overlay.state.currentPoint = { x: 200, y: 200 };
+            expect(overlay.state.startPoint.x).toBe(100);
+            expect(overlay.state.currentPoint.y).toBe(200);
+        });
+
+    });
+
+});
+
+describe('Preview Keyboard Shortcuts', () => {
+
+    beforeEach(() => {
+        // Reset preview state
+        preview.state.zoom = preview.DEFAULT_ZOOM;
+        preview.state.imagePath = null;
+        preview.state.isPanning = false;
+    });
+
+    describe('Zoom Shortcuts', () => {
+
+        test('Plus key should trigger zoom in', () => {
+            const event = new KeyboardEvent('keydown', { key: '+' });
+            expect(event.key).toBe('+');
+            // The actual zoom change would be handled by event listener
+        });
+
+        test('Minus key should trigger zoom out', () => {
+            const event = new KeyboardEvent('keydown', { key: '-' });
+            expect(event.key).toBe('-');
+        });
+
+        test('Equal key should also trigger zoom in', () => {
+            const event = new KeyboardEvent('keydown', { key: '=' });
+            expect(event.key).toBe('=');
+        });
+
+        test('Number 1 key for actual size', () => {
+            const event = new KeyboardEvent('keydown', { key: '1' });
+            expect(event.key).toBe('1');
+        });
+
+        test('F key for fit to window', () => {
+            const event = new KeyboardEvent('keydown', { key: 'f' });
+            expect(event.key).toBe('f');
+        });
+
+        test('Capital F also works for fit', () => {
+            const event = new KeyboardEvent('keydown', { key: 'F' });
+            expect(event.key).toBe('F');
+        });
+
+    });
+
+    describe('Action Shortcuts', () => {
+
+        test('Escape key for close', () => {
+            const event = new KeyboardEvent('keydown', { key: 'Escape' });
+            expect(event.key).toBe('Escape');
+        });
+
+        test('R key for recapture', () => {
+            const event = new KeyboardEvent('keydown', { key: 'r' });
+            expect(event.key).toBe('r');
+        });
+
+        test('Capital R also works for recapture', () => {
+            const event = new KeyboardEvent('keydown', { key: 'R' });
+            expect(event.key).toBe('R');
+        });
+
+        test('Ctrl+S for save', () => {
+            const event = new KeyboardEvent('keydown', {
+                key: 's',
+                ctrlKey: true
+            });
+            expect(event.key).toBe('s');
+            expect(event.ctrlKey).toBe(true);
+        });
+
+        test('Cmd+S for save on macOS', () => {
+            const event = new KeyboardEvent('keydown', {
+                key: 's',
+                metaKey: true
+            });
+            expect(event.key).toBe('s');
+            expect(event.metaKey).toBe(true);
+        });
+
+    });
+
+    describe('Zoom State Changes', () => {
+
+        test('zoomIn increases zoom level', () => {
+            const initialZoom = preview.state.zoom;
+            preview.zoomIn();
+            expect(preview.state.zoom).toBe(initialZoom + preview.ZOOM_STEP);
+        });
+
+        test('zoomOut decreases zoom level', () => {
+            preview.state.zoom = 1.5;
+            const initialZoom = preview.state.zoom;
+            preview.zoomOut();
+            expect(preview.state.zoom).toBe(initialZoom - preview.ZOOM_STEP);
+        });
+
+        test('zoomActual sets zoom to 100%', () => {
+            preview.state.zoom = 2.5;
+            preview.zoomActual();
+            expect(preview.state.zoom).toBe(preview.DEFAULT_ZOOM);
+        });
+
+    });
+
+});
+
+describe('Global Shortcut Configuration', () => {
+
+    describe('Shortcut Keys', () => {
+
+        test('global capture shortcut should use Ctrl+Shift+S on Windows', () => {
+            // This tests the expected shortcut key combination
+            const windowsShortcut = 'Ctrl+Shift+S';
+            expect(windowsShortcut).toContain('Ctrl');
+            expect(windowsShortcut).toContain('Shift');
+            expect(windowsShortcut).toContain('S');
+        });
+
+        test('global capture shortcut should use Cmd+Shift+S on macOS', () => {
+            const macShortcut = 'Cmd+Shift+S';
+            expect(macShortcut).toContain('Cmd');
+            expect(macShortcut).toContain('Shift');
+            expect(macShortcut).toContain('S');
+        });
+
+        test('shortcut modifier keys are valid', () => {
+            const validModifiers = ['Ctrl', 'Cmd', 'Shift', 'Alt', 'Meta'];
+            expect(validModifiers).toContain('Ctrl');
+            expect(validModifiers).toContain('Cmd');
+            expect(validModifiers).toContain('Shift');
+        });
+
+    });
+
+    describe('Keyboard Event Properties', () => {
+
+        test('can detect ctrl modifier', () => {
+            const event = new KeyboardEvent('keydown', { ctrlKey: true });
+            expect(event.ctrlKey).toBe(true);
+        });
+
+        test('can detect shift modifier', () => {
+            const event = new KeyboardEvent('keydown', { shiftKey: true });
+            expect(event.shiftKey).toBe(true);
+        });
+
+        test('can detect meta modifier (Cmd on macOS)', () => {
+            const event = new KeyboardEvent('keydown', { metaKey: true });
+            expect(event.metaKey).toBe(true);
+        });
+
+        test('can detect alt modifier', () => {
+            const event = new KeyboardEvent('keydown', { altKey: true });
+            expect(event.altKey).toBe(true);
+        });
+
+        test('can combine multiple modifiers', () => {
+            const event = new KeyboardEvent('keydown', {
+                ctrlKey: true,
+                shiftKey: true,
+                key: 's'
+            });
+            expect(event.ctrlKey).toBe(true);
+            expect(event.shiftKey).toBe(true);
+            expect(event.key).toBe('s');
+        });
+
+    });
+
+});
+
+describe('Tray Menu Integration', () => {
+
+    describe('Menu Item Configuration', () => {
+
+        test('capture menu item id should be "capture"', () => {
+            const menuItemId = 'capture';
+            expect(menuItemId).toBe('capture');
+        });
+
+        test('menu item should show shortcut hint', () => {
+            // Windows hint
+            const windowsHint = 'Ctrl+Shift+S';
+            expect(windowsHint.length).toBeGreaterThan(0);
+
+            // macOS hint using Unicode symbols
+            const macHint = '⌘⇧S';
+            expect(macHint.length).toBeGreaterThan(0);
+        });
+
+    });
+
+});
+
+describe('Keyboard Event Simulation', () => {
+
+    test('can create keydown event', () => {
+        const event = new KeyboardEvent('keydown', { key: 'a' });
+        expect(event.type).toBe('keydown');
+    });
+
+    test('can create keyup event', () => {
+        const event = new KeyboardEvent('keyup', { key: 'a' });
+        expect(event.type).toBe('keyup');
+    });
+
+    test('event has correct key property', () => {
+        const event = new KeyboardEvent('keydown', { key: 'Enter' });
+        expect(event.key).toBe('Enter');
+    });
+
+    test('event has correct code property', () => {
+        const event = new KeyboardEvent('keydown', { key: 'a', code: 'KeyA' });
+        expect(event.code).toBe('KeyA');
+    });
+
+    test('preventDefault can be called', () => {
+        const event = new KeyboardEvent('keydown', { key: 'a', cancelable: true });
+        expect(() => event.preventDefault()).not.toThrow();
+    });
+
+});
+
+describe('Cross-Window Communication', () => {
+
+    test('Tauri invoke is available for window operations', () => {
+        // In test environment, __TAURI__ is mocked
+        expect(window.__TAURI__).toBeDefined();
+        expect(window.__TAURI__.invoke).toBeDefined();
+    });
+
+    test('invoke is callable', () => {
+        expect(typeof window.__TAURI__.invoke).toBe('function');
+    });
+
+});

--- a/wrapper/src/tests/test-helpers.js
+++ b/wrapper/src/tests/test-helpers.js
@@ -1,0 +1,190 @@
+/**
+ * Shared Test Helpers
+ * Common utilities and setup functions for test files
+ */
+
+const overlay = require('../overlay.js');
+const preview = require('../preview.js');
+
+/**
+ * Reset overlay module state to initial values
+ * Use in beforeEach() to ensure clean state between tests
+ */
+function resetOverlayState() {
+    overlay.state.isSelecting = false;
+    overlay.state.isDragging = false;
+    overlay.state.startPoint = null;
+    overlay.state.currentPoint = null;
+    overlay.state.selectionRect = null;
+    overlay.state.animationFrameId = null;
+    overlay.state.instructionsVisible = true;
+    overlay.state.permissionChecked = false;
+    overlay.state.hasPermission = true;
+}
+
+/**
+ * Reset preview module state to initial values
+ * Use in beforeEach() to ensure clean state between tests
+ */
+function resetPreviewState() {
+    preview.state.imagePath = null;
+    preview.state.imageWidth = 0;
+    preview.state.imageHeight = 0;
+    preview.state.fileSize = 0;
+    preview.state.zoom = preview.DEFAULT_ZOOM;
+    preview.state.isPanning = false;
+    preview.state.panStart = { x: 0, y: 0 };
+    preview.state.scrollStart = { x: 0, y: 0 };
+}
+
+/**
+ * Reset all module states at once
+ * Convenient for integration tests that use multiple modules
+ */
+function resetAllStates() {
+    resetOverlayState();
+    resetPreviewState();
+}
+
+/**
+ * Create a mock selection scenario
+ * @param {Object} options - Configuration options
+ * @param {Object} options.start - Start point {x, y}
+ * @param {Object} options.end - End point {x, y}
+ * @param {boolean} options.isDragging - Whether currently dragging
+ * @returns {Object} The calculated selection rect
+ */
+function createMockSelection(options = {}) {
+    const start = options.start || { x: 100, y: 100 };
+    const end = options.end || { x: 300, y: 300 };
+    const isDragging = options.isDragging !== undefined ? options.isDragging : false;
+
+    overlay.state.isSelecting = true;
+    overlay.state.isDragging = isDragging;
+    overlay.state.startPoint = start;
+    overlay.state.currentPoint = end;
+
+    const rect = overlay.calculateRect(start, end);
+    overlay.state.selectionRect = rect;
+
+    return rect;
+}
+
+/**
+ * Create a mock capture result for preview testing
+ * @param {Object} options - Configuration options
+ * @returns {Object} Mock capture result
+ */
+function createMockCaptureResult(options = {}) {
+    return {
+        file_path: options.file_path || '/tmp/test_capture_20231118_120000_abc123.png',
+        width: options.width || 300,
+        height: options.height || 200,
+        timestamp: options.timestamp || '2023-11-18 12:00:00'
+    };
+}
+
+/**
+ * Create a mock monitor info object
+ * @param {Object} options - Configuration options
+ * @returns {Object} Mock monitor info
+ */
+function createMockMonitor(options = {}) {
+    return {
+        id: options.id || 0,
+        name: options.name || 'Mock Monitor',
+        x: options.x || 0,
+        y: options.y || 0,
+        width: options.width || 1920,
+        height: options.height || 1080,
+        dpi_scale: options.dpi_scale || 1.0,
+        is_primary: options.is_primary !== undefined ? options.is_primary : true
+    };
+}
+
+/**
+ * Simulate a complete mouse drag operation
+ * @param {Object} startPoint - {x, y} starting position
+ * @param {Object} endPoint - {x, y} ending position
+ * @returns {Object} The resulting selection rect
+ */
+function simulateMouseDrag(startPoint, endPoint) {
+    // Mouse down
+    overlay.state.isSelecting = true;
+    overlay.state.isDragging = true;
+    overlay.state.startPoint = startPoint;
+    overlay.state.currentPoint = startPoint;
+
+    // Mouse move
+    overlay.state.currentPoint = endPoint;
+    const rect = overlay.calculateRect(startPoint, endPoint);
+    overlay.state.selectionRect = rect;
+
+    // Mouse up
+    overlay.state.isDragging = false;
+
+    return rect;
+}
+
+/**
+ * Assert that two rectangles are equal
+ * @param {Object} rect1 - First rectangle
+ * @param {Object} rect2 - Second rectangle
+ */
+function expectRectsEqual(rect1, rect2) {
+    expect(rect1.x).toBe(rect2.x);
+    expect(rect1.y).toBe(rect2.y);
+    expect(rect1.width).toBe(rect2.width);
+    expect(rect1.height).toBe(rect2.height);
+}
+
+/**
+ * Create a multi-monitor setup for testing
+ * @returns {Array} Array of monitor info objects
+ */
+function createMultiMonitorSetup() {
+    return [
+        createMockMonitor({
+            id: 0,
+            name: 'Primary Monitor',
+            x: 0,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            is_primary: true
+        }),
+        createMockMonitor({
+            id: 1,
+            name: 'Secondary Monitor',
+            x: 1920,
+            y: 0,
+            width: 1920,
+            height: 1080,
+            dpi_scale: 1.5,
+            is_primary: false
+        })
+    ];
+}
+
+module.exports = {
+    // State reset functions
+    resetOverlayState,
+    resetPreviewState,
+    resetAllStates,
+
+    // Mock data creators
+    createMockSelection,
+    createMockCaptureResult,
+    createMockMonitor,
+    createMultiMonitorSetup,
+
+    // Simulation helpers
+    simulateMouseDrag,
+
+    // Assertion helpers
+    expectRectsEqual,
+
+    // Re-export modules for convenience
+    overlay,
+    preview
+};


### PR DESCRIPTION
## Summary
- Add screen area capture functionality with click-and-drag selection
- Add preview window with zoom (10%-500%) and pan controls
- Add global keyboard shortcut (Ctrl+Shift+S / Cmd+Shift+S)
- Add tray menu "Capture Screen" option
- Support multi-monitor and DPI scaling

## Implementation
- **Backend**: Rust capture module with Windows GDI API, mock backend for cross-platform testing
- **Overlay**: Fullscreen transparent overlay with 60fps render loop
- **Preview**: Image display with zoom, pan, Save As, and recapture
- **Edge cases**: Permission checks, validation feedback, error handling

## Test plan
- [ ] Verify 262 tests pass (56 Rust + 206 JavaScript)
- [ ] Test global shortcut triggers capture overlay
- [ ] Test tray menu "Capture Screen" option
- [ ] Test selection with minimum size validation (10x10px)
- [ ] Test preview window zoom/pan controls
- [ ] Test Save As functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)